### PR TITLE
Improve the search API

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,30 @@ This will load portion of the data from MySQL to ES
 python manage.py enrich 
 ```
 
+##### Setting up Cron job
+
+The command below will set up a cron job to update trackdb status every Sunday at 00:00
+
+```shell script
+python manage.py crontab add 
+```
+
+Make sure to run this command every time CRONJOBS is changed in any way. 
+
+> Cron jobs are defined in `thr/settings/base.py`
+
+To get all the active CRONJOBS, run the following command 
+```shell script
+python manage.py crontab show
+```
+
+To remove all the defined CRONJOBS from crontab, run the following command
+```shell script
+python manage.py crontab remove
+```
+
+> You need to restart the server for changes to take effect 
+
 ## APIs Endpoints
 
 See [APIs Endpoints status](apis_endpoints_status.md)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,10 @@ attrs==20.2.0
 certifi==2020.6.20
 chardet==4.0.0
 coverage==5.2.1
+dj-rest-auth==2.1.4
 Django==2.2.20
 django-cors-headers==3.5.0
+django-crontab==0.7.1
 django-elasticsearch-dsl>=6.0.0,<7.0.0
 django-elasticsearch-dsl-drf==0.20.8
 django-mysql==3.8.1

--- a/search/documents.py
+++ b/search/documents.py
@@ -44,32 +44,98 @@ class TrackdbDocument(Document):
     the search.api.serializers controls what will be shown after triggering a search query
     """
 
-    type = fields.StringField(attr='data_type_indexing')
+    type = fields.StringField(
+        attr='data_type_indexing',
+        analyzer=html_strip,
+        fields={
+            'raw': fields.KeywordField(),
+        }
+    )
 
     hub = fields.ObjectField(properties={
-        'name': fields.KeywordField(),
-        'short_label': fields.StringField(),
-        'long_label': fields.StringField(),
-        'url': fields.StringField(),
-        'description_url': fields.StringField(),
-        'email': fields.StringField(),
+        'name': fields.StringField(
+            analyzer=html_strip,
+            fields={
+                'raw': fields.KeywordField(),
+            }
+        ),
+        'short_label': fields.StringField(
+            analyzer=html_strip,
+            fields={
+                'raw': fields.KeywordField(),
+            }
+        ),
+        'long_label': fields.StringField(
+            analyzer=html_strip,
+            fields={
+                'raw': fields.KeywordField(),
+            }
+        ),
+        'url': fields.StringField(
+            analyzer=html_strip,
+            fields={
+                'raw': fields.KeywordField(),
+            }
+        ),
+        'description_url': fields.StringField(
+            analyzer=html_strip,
+            fields={
+                'raw': fields.KeywordField(),
+            }
+        ),
+        'email': fields.StringField(
+            analyzer=html_strip,
+            fields={
+                'raw': fields.KeywordField(),
+            }
+        ),
     })
 
     assembly = fields.ObjectField(
         attr='assembly_indexing',
         properties={
-            'accession': fields.KeywordField(),
-            'name': fields.KeywordField(),
-            'long_name': fields.StringField(),
-            'ucsc_synonym': fields.KeywordField(),
+            'accession': fields.StringField(
+                analyzer=html_strip,
+                fields={
+                    'raw': fields.KeywordField(),
+                }
+            ),
+            'name': fields.StringField(
+                analyzer=html_strip,
+                fields={
+                    'raw': fields.KeywordField(),
+                }
+            ),
+            'long_name': fields.StringField(
+                analyzer=html_strip,
+                fields={
+                    'raw': fields.KeywordField(),
+                }
+            ),
+            'ucsc_synonym': fields.StringField(
+                analyzer=html_strip,
+                fields={
+                    'raw': fields.KeywordField(),
+                }
+            ),
     })
 
     species = fields.ObjectField(
         attr='species_indexing',
         properties={
             'taxon_id': fields.IntegerField(),
-            'scientific_name': fields.KeywordField(),
-            'common_name': fields.KeywordField(),
+            'scientific_name': fields.StringField(
+                analyzer=html_strip,
+                fields={
+                    'raw': fields.KeywordField(),
+                }
+            ),
+            'common_name': fields.StringField(
+                analyzer=html_strip,
+                fields={
+                    'raw': fields.KeywordField(),
+                }
+            ),
     })
 
     status = fields.ObjectField()
@@ -89,8 +155,6 @@ class TrackdbDocument(Document):
             'version',
             'created',
             'updated',
-            # 'source_url',
-            # 'source_checksum',
         ]
 
     # Meta is used to set dynamic mapping to false to avoid mapping explosion

--- a/search/documents.py
+++ b/search/documents.py
@@ -72,6 +72,7 @@ class TrackdbDocument(Document):
             'common_name': fields.KeywordField(),
     })
 
+    status = fields.ObjectField()
     configuration = fields.ObjectField()
     data = fields.NestedField()
 
@@ -88,9 +89,6 @@ class TrackdbDocument(Document):
             'version',
             'created',
             'updated',
-            # 'status_message',
-            # 'status_last_update',
-            # 'status',
             # 'source_url',
             # 'source_checksum',
         ]
@@ -98,5 +96,6 @@ class TrackdbDocument(Document):
     # Meta is used to set dynamic mapping to false to avoid mapping explosion
     # https://www.elastic.co/guide/en/elasticsearch/reference/6.3/mapping.html#mapping-limit-settings
     class Meta:
+        model = Trackdb
         all = MetaField(enabled=False)
         dynamic = MetaField('false')

--- a/search/serializers.py
+++ b/search/serializers.py
@@ -21,10 +21,14 @@ import search.documents
 class TrackdbDocumentSerializer(DocumentSerializer):
     """Serializer for Trackdb document."""
 
-    id = serializers.SerializerMethodField()
-    score = serializers.SerializerMethodField()
+    # TODO: find a way to add score if needed
+    # score = serializers.SerializerMethodField()
     type = serializers.SerializerMethodField()
     status = serializers.SerializerMethodField()
+    source = serializers.SerializerMethodField()
+    owner = serializers.SerializerMethodField()
+    created = serializers.SerializerMethodField()
+    configuration = serializers.SerializerMethodField()
 
     class Meta(object):
         """Meta options."""
@@ -33,14 +37,17 @@ class TrackdbDocumentSerializer(DocumentSerializer):
         document = search.documents.TrackdbDocument
 
         fields = [
-            'score',
-            'id',
+            'trackdb_id',
             'version',
             'type',
             'status',
             'hub',
             'species',
             'assembly',
+            'source',
+            'owner',
+            'created',
+            'configuration',
         ]
 
     def get_type(self, obj):
@@ -61,12 +68,30 @@ class TrackdbDocumentSerializer(DocumentSerializer):
         except Exception:
             return None
 
-    def get_score(self, obj):
-        if hasattr(obj.meta, 'score'):
-            return obj.meta.score
-        return None
+    def get_source(self, obj):
+        """Represent source object."""
+        try:
+            return obj.source.to_dict()
+        except Exception:
+            return {}
 
-    def get_id(self, obj):
-        if hasattr(obj.meta, 'id'):
-            return obj.meta.id
-        return None
+    def get_owner(self, obj):
+        """Represent the owner value."""
+        try:
+            return obj.owner
+        except Exception:
+            return ''
+
+    def get_created(self, obj):
+        """Represent created value."""
+        try:
+            return obj.created
+        except Exception:
+            return ''
+
+    def get_configuration(self, obj):
+        """Represent configuration value."""
+        try:
+            return obj.configuration.to_dict()
+        except Exception:
+            return {}

--- a/search/serializers.py
+++ b/search/serializers.py
@@ -21,14 +21,12 @@ import search.documents
 class TrackdbDocumentSerializer(DocumentSerializer):
     """Serializer for Trackdb document."""
 
-    # TODO: find a way to add score if needed
+    # TODO: find a way to add the score if needed
     # score = serializers.SerializerMethodField()
-    type = serializers.SerializerMethodField()
-    status = serializers.SerializerMethodField()
     source = serializers.SerializerMethodField()
     owner = serializers.SerializerMethodField()
-    created = serializers.SerializerMethodField()
-    configuration = serializers.SerializerMethodField()
+    status = serializers.SerializerMethodField()
+    type = serializers.SerializerMethodField()
 
     class Meta(object):
         """Meta options."""
@@ -38,24 +36,17 @@ class TrackdbDocumentSerializer(DocumentSerializer):
 
         fields = [
             'trackdb_id',
-            'version',
-            'type',
-            'status',
+            'source',
             'hub',
+            'version',
+            'owner',
+            'status',
             'species',
             'assembly',
-            'source',
-            'owner',
             'created',
+            'type',
             'configuration',
         ]
-
-    def get_type(self, obj):
-        """Represent data type value."""
-        try:
-            return obj.type
-        except Exception:
-            return ''
 
     def get_status(self, obj):
         """Represent status value."""
@@ -82,16 +73,9 @@ class TrackdbDocumentSerializer(DocumentSerializer):
         except Exception:
             return ''
 
-    def get_created(self, obj):
-        """Represent created value."""
+    def get_type(self, obj):
+        """Represent type value."""
         try:
-            return obj.created
+            return obj.type
         except Exception:
             return ''
-
-    def get_configuration(self, obj):
-        """Represent configuration value."""
-        try:
-            return obj.configuration.to_dict()
-        except Exception:
-            return {}

--- a/search/serializers.py
+++ b/search/serializers.py
@@ -23,6 +23,8 @@ class TrackdbDocumentSerializer(DocumentSerializer):
 
     id = serializers.SerializerMethodField()
     score = serializers.SerializerMethodField()
+    type = serializers.SerializerMethodField()
+    status = serializers.SerializerMethodField()
 
     class Meta(object):
         """Meta options."""
@@ -31,23 +33,33 @@ class TrackdbDocumentSerializer(DocumentSerializer):
         document = search.documents.TrackdbDocument
 
         fields = [
-            'hub',
-            'public',
-            'description',
-            'assembly',
-            'type',
-            'species',
+            'score',
+            'id',
             'version',
-            'created',
-            'updated',
-            # 'configuration',
-            # 'data',
-            # 'status_message',
-            # 'status_last_update',
-            # 'status',
-            # 'source_url',
-            # 'source_checksum',
+            'type',
+            'status',
+            'hub',
+            'species',
+            'assembly',
         ]
+
+    def get_type(self, obj):
+        """Represent data type value."""
+        try:
+            return obj.type
+        except Exception:
+            return ''
+
+    def get_status(self, obj):
+        """Represent status value."""
+        try:
+            minimal_status_info = {
+                "last_update": obj.status.last_update,
+                "message": obj.status.message
+            }
+            return minimal_status_info
+        except Exception:
+            return None
 
     def get_score(self, obj):
         if hasattr(obj.meta, 'score'):

--- a/search/urls.py
+++ b/search/urls.py
@@ -13,11 +13,10 @@
 """
 
 from django.urls import path
-from search.views import TrackdbDocumentListView, TrackdbDocumentDetailView, TrackdbDocumentView
+from search.views import TrackdbDocumentDetailView, TrackdbDocumentListView
 
 
 urlpatterns = [
-    path('', TrackdbDocumentView.as_view({'get': 'list'})),
-    # path('', TrackdbDocumentListView.as_view()),
+    path('', TrackdbDocumentListView.as_view({'post': 'list'})),
     path('trackdb/<int:pk>/', TrackdbDocumentDetailView.as_view()),
 ]

--- a/search/urls.py
+++ b/search/urls.py
@@ -13,10 +13,11 @@
 """
 
 from django.urls import path
-from search.views import TrackdbDocumentListView, TrackdbDocumentDetailView
+from search.views import TrackdbDocumentListView, TrackdbDocumentDetailView, TrackdbDocumentView
 
 
 urlpatterns = [
-    path('', TrackdbDocumentListView.as_view()),
+    path('', TrackdbDocumentView.as_view({'get': 'list'})),
+    # path('', TrackdbDocumentListView.as_view()),
     path('trackdb/<int:pk>/', TrackdbDocumentDetailView.as_view()),
 ]

--- a/search/views.py
+++ b/search/views.py
@@ -20,6 +20,45 @@ from rest_framework.views import APIView
 from search.documents import TrackdbDocument
 from search.serializers import TrackdbDocumentSerializer
 
+from django_elasticsearch_dsl_drf.filter_backends import (
+    FilteringFilterBackend,
+    OrderingFilterBackend,
+    SearchFilterBackend,
+    DefaultOrderingFilterBackend,
+)
+from django_elasticsearch_dsl_drf.viewsets import DocumentViewSet
+
+
+class TrackdbDocumentView(DocumentViewSet):
+    """The TrackdbDocument view."""
+
+    document = TrackdbDocument
+    serializer_class = TrackdbDocumentSerializer
+    lookup_field = 'id'
+    filter_backends = [
+        FilteringFilterBackend,
+        OrderingFilterBackend,
+        DefaultOrderingFilterBackend,
+        SearchFilterBackend,
+    ]
+    # Define search fields
+    search_fields = (
+        'hub.shortLabel', 'hub.longLabel', 'hub.name',
+        'type', 'species.common_name', 'species.scientific_name'
+    )
+    # Define filtering fields
+    filter_fields = {
+        'id': None,
+        'hub.name': 'hub.name.raw',
+    }
+    # Define ordering fields
+    ordering_fields = {
+        'id': None,
+        'hub.name': None,
+    }
+    # Specify default ordering
+    ordering = ('_id', 'hub.name',)
+
 
 class TrackdbDocumentListView(APIView):
     """The TrackhubDocumentList view."""

--- a/thr/settings/base.py
+++ b/thr/settings/base.py
@@ -28,6 +28,7 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 """
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
+# BASE_DIR her is 'thr/thr'
 BASE_DIR = Path(__file__).resolve(strict=True).parent.parent
 
 # Quick-start development settings - unsuitable for production
@@ -65,6 +66,7 @@ INSTALLED_APPS = [
     # Django REST framework Elasticsearch integration
     'django_elasticsearch_dsl_drf',
     'django_mysql',
+    'django_crontab',
 ]
 
 REST_FRAMEWORK = {
@@ -198,6 +200,14 @@ LOGGING = {
         }
     }
 }
+
+# cron job scheduled to be run at 00:00 every Sunday
+CRONJOBS = [
+    ('0 0 * * SUN', 'thr.trackdbs.update_status.update_trackdb_status', '>> ../../thr.log')
+]
+
+# redirect errors to stdout
+CRONTAB_COMMAND_SUFFIX = '2>&1'
 
 # Internationalization
 # https://docs.djangoproject.com/en/2.2/topics/i18n/

--- a/thr/settings/base.py
+++ b/thr/settings/base.py
@@ -73,7 +73,7 @@ REST_FRAMEWORK = {
     ],
     'DEFAULT_PAGINATION_CLASS':
         'rest_framework.pagination.PageNumberPagination',
-    'PAGE_SIZE': 10,
+    'PAGE_SIZE': 5,
     'ORDERING_PARAM': 'ordering',
 }
 

--- a/trackdbs/update_status.py
+++ b/trackdbs/update_status.py
@@ -1,0 +1,35 @@
+"""
+.. See the NOTICE file distributed with this work for additional information
+   regarding copyright ownership.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+"""
+import logging
+import trackhubs
+from trackhubs.tracks_status import fetch_tracks_status
+
+logger = logging.getLogger(__name__)
+
+
+def update_trackdb_status():
+    """
+    This function will be executed automatically via cron.
+    It checks and updates all trackdb (bigDataUrl) status
+    both in ES and MySQL
+    """
+    all_trackdbs = trackhubs.models.Trackdb.objects.all()
+    for trackdb in all_trackdbs:
+        tracks_status = fetch_tracks_status(trackdb.__dict__, trackdb.source_url)
+        # update the status JSON field in MySQL
+        # apparently, updating MySQL magically update ES too!
+        trackdb.status = tracks_status
+        trackdb.save()
+
+        logger.info('Status updated successfully: ', tracks_status)

--- a/trackhubs/hub_check.py
+++ b/trackhubs/hub_check.py
@@ -43,7 +43,7 @@ def hub_check(hub_url):
 
     print("[INFO] Checking " + hub_url + "...")
     hub_check_result = subprocess.run(
-        ["tools/hubCheck", "-noTracks", hub_url], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True
+        ["tools/hubCheck", "-noTracks", "-verbose=2", hub_url], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True
     )
     print(hub_check_result)
 

--- a/trackhubs/management/commands/enrich.py
+++ b/trackhubs/management/commands/enrich.py
@@ -14,7 +14,7 @@
 
 from django.core.management.base import BaseCommand
 
-from trackhubs.tracks_status import save_tracks_status
+from trackhubs.tracks_status import fetch_tracks_status
 import trackhubs.models
 
 
@@ -26,7 +26,7 @@ class Command(BaseCommand):
     def _enrich_docs(self):
         all_trackdbs = trackhubs.models.Trackdb.objects.all()
         for trackdb in all_trackdbs:
-            tracks_status = save_tracks_status(trackdb.__dict__, trackdb.source_url)
+            tracks_status = fetch_tracks_status(trackdb.__dict__, trackdb.source_url)
             trackdb.update_trackdb_document(trackdb.hub, trackdb.data, trackdb.configuration, tracks_status)
 
     def handle(self, *args, **options):

--- a/trackhubs/management/commands/enrich.py
+++ b/trackhubs/management/commands/enrich.py
@@ -11,11 +11,10 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 """
-import elasticsearch
-from django.core.management.base import BaseCommand, CommandError
-from django.db.models import Count
 
-from trackhubs.translator import save_and_update_document
+from django.core.management.base import BaseCommand
+
+from trackhubs.tracks_status import save_tracks_status
 import trackhubs.models
 
 
@@ -27,7 +26,8 @@ class Command(BaseCommand):
     def _enrich_docs(self):
         all_trackdbs = trackhubs.models.Trackdb.objects.all()
         for trackdb in all_trackdbs:
-            trackdb.update_trackdb_document(trackdb.hub, trackdb.data, trackdb.configuration)
+            tracks_status = save_tracks_status(trackdb.__dict__, trackdb.source_url)
+            trackdb.update_trackdb_document(trackdb.hub, trackdb.data, trackdb.configuration, tracks_status)
 
     def handle(self, *args, **options):
         # the command below will enrich all trackdbs stored in the DB

--- a/trackhubs/tracks_status.py
+++ b/trackhubs/tracks_status.py
@@ -68,7 +68,7 @@ def check_response(url):
         return "{}".format(e.reason)
 
 
-def save_tracks_status(trackdb_dict, trackdb_url):
+def fetch_tracks_status(trackdb_dict, trackdb_url):
     """
     Create the tracks status dictionary
     :param trackdb_dict: the trackdb dictionary containing all tracks

--- a/trackhubs/translator.py
+++ b/trackhubs/translator.py
@@ -25,7 +25,7 @@ from trackhubs.constants import DATA_TYPES, FILE_TYPES, VISIBILITY
 from trackhubs.hub_check import hub_check
 from trackhubs.models import Trackdb, GenomeAssemblyDump
 from trackhubs.parser import parse_file_from_url
-from trackhubs.tracks_status import save_tracks_status, fix_big_data_url
+from trackhubs.tracks_status import fetch_tracks_status, fix_big_data_url
 
 logger = logging.getLogger(__name__)
 
@@ -392,7 +392,7 @@ def save_and_update_document(hub_url, data_type, current_user):
             trackdbs_info = parse_file_from_url(trackdb_url, is_trackdb=True)
             # logger.debug("trackdbs_info: {}".format(json.dumps(trackdbs_info, indent=4)))
 
-            tracks_status = save_tracks_status(trackdbs_info, trackdb_url)
+            tracks_status = fetch_tracks_status(trackdbs_info, trackdb_url)
 
             trackdb_data = []
             trackdb_configuration = {}


### PR DESCRIPTION
What have been done:
- Improved search analyzer and added data type to POST search filter
- Replaced `elasticsearch_dsl` with `django_elasticsearch_dsl_drf`: no need to reinventing the wheel since it offers ordering, pagination and facets, it needed some tweaks to be adapted to THR requirements (e.g overriding the default GET search with POST search and altering/renaming response fields).
- Added status and restructured search reponse objects