### PR TITLE
Add forgot/reset password endpoints

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -36,7 +36,7 @@ def create_user_resource(django_user_model):
     """
     Create a temporary user then return the user and token
     """
-    user = django_user_model.objects.create_user(username='test_user', password='test-password')
+    user = django_user_model.objects.create_user(username='testuser', password='test-password', email='testuser@mail.com')
     token, _ = Token.objects.get_or_create(user=user)
     return user, token
 

--- a/thr/settings/base.py
+++ b/thr/settings/base.py
@@ -237,7 +237,14 @@ LOGIN_REDIRECT_URL = 'dashboard'
 LOGOUT_REDIRECT_URL = 'thr_home'
 LOGIN_URL = 'login'
 
-EMAIL_HOST = "localhost"
-EMAIL_PORT = 1025
+# this can be tested locally using the command:
+# python -m smtpd -n -c DebuggingServer localhost:1025
+EMAIL_HOST = 'localhost'  # 'smtp'
+EMAIL_PORT = 1025  # 587
+EMAIL_HOST_USER = ''  # trackhub-registry@ebi.ac.uk
+EMAIL_HOST_PASSWORD = ''  # email password
+EMAIL_USE_TLS = False  # True
+
+FRONTEND_URL = 'localhost:8000/api'
 
 THR_VERSION = "0.6"

--- a/thr/settings/base.py
+++ b/thr/settings/base.py
@@ -246,5 +246,6 @@ EMAIL_HOST_PASSWORD = ''  # email password
 EMAIL_USE_TLS = False  # True
 
 FRONTEND_URL = 'localhost:3000'
+BACKEND_URL = 'localhost:8000'
 
 THR_VERSION = "0.6"

--- a/thr/settings/base.py
+++ b/thr/settings/base.py
@@ -245,6 +245,6 @@ EMAIL_HOST_USER = ''  # trackhub-registry@ebi.ac.uk
 EMAIL_HOST_PASSWORD = ''  # email password
 EMAIL_USE_TLS = False  # True
 
-FRONTEND_URL = 'localhost:8000/api'
+FRONTEND_URL = 'localhost:3000'
 
 THR_VERSION = "0.6"

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -145,8 +145,7 @@ class ResetPasswordEmailSerializer(serializers.Serializer):
         fields = ['email']
 
     def validate(self, attrs):
-        if User.objects.filter(email=attrs['email']).exists():
-            return super().validate(attrs)
+        return super().validate(attrs)
 
 
 class SetNewPasswordSerializer(serializers.Serializer):
@@ -179,5 +178,8 @@ class SetNewPasswordSerializer(serializers.Serializer):
             })
 
         user.set_password(new_password)
+        # TODO: uncomment the line below after email verification branch is merged
+        # resetting the password automatically activates the account
+        # user.is_account_activated = True
         user.save()
         return user

--- a/users/urls.py
+++ b/users/urls.py
@@ -15,7 +15,8 @@
 from django.urls import path
 from rest_framework.authtoken.views import obtain_auth_token
 
-from users.views import RegistrationViewAPI, LogoutViewAPI, UserDetailsView, ChangePasswordView
+from users.views import RegistrationViewAPI, LogoutViewAPI, UserDetailsView, ChangePasswordView, \
+    ValidateResetPasswordAPI, ResetPasswordEmailView, SetNewPasswordAPI
 
 urlpatterns = [
     path('user/', UserDetailsView.as_view(), name='user_api'),
@@ -24,4 +25,7 @@ urlpatterns = [
     path('logout', LogoutViewAPI.as_view(), name='logout_api'),
     path('logout', LogoutViewAPI.as_view(), name='logout_api'),
     path('change_password', ChangePasswordView.as_view(), name='change_password_api'),
+    path('reset_password_email',  ResetPasswordEmailView.as_view(), name='reset_password_email_api'),
+    path('reset_password/<uidb64>/<token>',  ValidateResetPasswordAPI.as_view(), name='validate_reset_password_api'),
+    path('reset_password_complete',  SetNewPasswordAPI.as_view(), name='set_new_password_api'),
 ]

--- a/users/urls.py
+++ b/users/urls.py
@@ -26,6 +26,6 @@ urlpatterns = [
     path('logout', LogoutViewAPI.as_view(), name='logout_api'),
     path('change_password', ChangePasswordView.as_view(), name='change_password_api'),
     path('reset_password_email',  ResetPasswordEmailView.as_view(), name='reset_password_email_api'),
-    path('reset_password/<uidb64>/<token>',  ValidateResetPasswordAPI.as_view(), name='validate_reset_password_api'),
+    path('reset_password',  ValidateResetPasswordAPI.as_view(), name='validate_reset_password_api'),
     path('reset_password_complete',  SetNewPasswordAPI.as_view(), name='set_new_password_api'),
 ]

--- a/users/views.py
+++ b/users/views.py
@@ -12,6 +12,7 @@
    limitations under the License.
 """
 
+from thr import settings
 from django.contrib.auth import logout
 from rest_framework import status, authentication, permissions, generics
 from rest_framework.authtoken.models import Token
@@ -19,8 +20,14 @@ from rest_framework.generics import UpdateAPIView
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from users.serializers import RegistrationSerializer, CustomUserSerializer, ChangePasswordSerializer
+from users.models import CustomUser as User
+from users.serializers import RegistrationSerializer, CustomUserSerializer, ChangePasswordSerializer, \
+    ResetPasswordEmailSerializer, SetNewPasswordSerializer
 
+from django.contrib.auth.tokens import PasswordResetTokenGenerator
+from django.utils.encoding import smart_str, force_str, smart_bytes, DjangoUnicodeDecodeError
+from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
+from django.core.mail import send_mail
 
 class RegistrationViewAPI(APIView):
     """
@@ -114,5 +121,91 @@ class ChangePasswordView(UpdateAPIView):
         # return a success message with the new token
         return Response(
             {'success': 'Your password is updated successfully!', 'token': token.key},
+            status=status.HTTP_200_OK
+        )
+
+
+class ResetPasswordEmailView(APIView):
+    """
+    Endpoint allowing the user to submit their email
+    to send them a password reset link
+    """
+
+    serializer_class = ResetPasswordEmailSerializer
+
+    def post(self, request):
+        serializer = self.serializer_class(data=request.data)
+        email = request.data['email']
+
+        if serializer.is_valid():
+            user = User.objects.filter(email=email).first()
+            if user:
+                # encode the user id
+                uidb64 = urlsafe_base64_encode(str(user.id).encode())
+                # create the token
+                token = PasswordResetTokenGenerator().make_token(user)
+
+                # send the email
+                fe_url = settings.FRONTEND_URL
+                full_url = 'http://' + fe_url + "/reset_password/" + uidb64 + "/" + token
+
+                send_mail(
+                    subject='[Trackhub Registry] Password reset',
+                    from_email='bilal@ebi.ac.uk',  # 'trackhub-registry@ebi.ac.uk',
+                    message='Hi, \nPlease use the link below to reset your password \n' + full_url,
+                    recipient_list=[user.email],
+                    fail_silently=False
+                )
+        return Response(
+            {'success': 'Please check your email, We have sent you a link to reset your password'},
+            status=status.HTTP_200_OK
+        )
+
+
+class ValidateResetPasswordAPI(APIView):
+    """
+    Validate reset password token
+    """
+
+    def get(self, request, uidb64, token):
+        try:
+            # get a human readable string of user ID
+            id = smart_str(urlsafe_base64_decode(uidb64))
+            user = User.objects.get(id=id)
+
+            # make sure that user isn't using this token for a second time
+            if not PasswordResetTokenGenerator().check_token(user, token):
+                return Response(
+                    {'error': 'Token is not valid, please request a new one'},
+                    status=status.HTTP_400_BAD_REQUEST
+                )
+
+            return Response(
+                {'success': 'Credentials are Valid', 'uidb64': uidb64, 'token': token},
+                status=status.HTTP_200_OK
+
+            )
+
+        except DjangoUnicodeDecodeError as exp:
+            return Response(
+                {'error': 'Token is not valid, please request a new one'},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+
+class SetNewPasswordAPI(APIView):
+    """
+    Allow the user to reset the password
+    """
+
+    serializer_class = SetNewPasswordSerializer
+
+    def patch(self, request):
+        serializer = self.serializer_class(data=request.data)
+
+        serializer.is_valid(raise_exception=True)
+
+        return Response(
+            {'success': 'Password reset successfully!'},
             status=status.HTTP_200_OK
         )

--- a/users/views.py
+++ b/users/views.py
@@ -29,6 +29,7 @@ from django.utils.encoding import smart_str, force_str, smart_bytes, DjangoUnico
 from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
 from django.core.mail import send_mail
 
+
 class RegistrationViewAPI(APIView):
     """
     User registration endpoint, if the request is successful,

--- a/users/views.py
+++ b/users/views.py
@@ -148,7 +148,7 @@ class ResetPasswordEmailView(APIView):
 
                 # send the email
                 fe_url = settings.FRONTEND_URL
-                full_url = 'http://' + fe_url + "/reset_password/" + uidb64 + "/" + token
+                full_url = 'http://' + fe_url + "/reset_password?uidb64=" + uidb64 + "&token=" + token
 
                 send_mail(
                     subject='[Trackhub Registry] Password reset',
@@ -168,7 +168,9 @@ class ValidateResetPasswordAPI(APIView):
     Validate reset password token
     """
 
-    def get(self, request, uidb64, token):
+    def get(self, request):
+        uidb64 = request.GET.get('uidb64')
+        token = request.GET.get('token')
         try:
             # get a human readable string of user ID
             id = smart_str(urlsafe_base64_decode(uidb64))


### PR DESCRIPTION
Added the following endpoints:

- `/api/reset_password_email`: allows the user to submit their email to send them a password reset link
- `/api/reset_password`: Validates reset password token
- `/api/reset_password_complete`: Allows the user to reset the password