### PR TITLE
Fix Manager isn't available for custom user and replaced JSON fields

### DIFF
--- a/.env
+++ b/.env
@@ -17,6 +17,9 @@ DB_PASSWORD=password
 DB_HOST=mysql
 DB_PORT=3306
 
+ES_HOST=elasticsearch:9200
+ES_INDEX=trackhubs
+
 # Docker compose variables
 MYSQL_VERSION=5.7
 ELASTIC_VERSION=6.3.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,9 @@ RUN apk del .tmp
 
 # run entrypoint.sh
 RUN chmod +x /usr/src/app/entrypoint.sh
-ENTRYPOINT ["/usr/src/app/entrypoint.sh"]
+# NOTE: Uncomment the line below when running docker compose
+# It's disabled for the sake of Kubernetes deployment
+# ENTRYPOINT ["/usr/src/app/entrypoint.sh"]
 
 
 # Useful resources:

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.7.9-alpine
+FROM python:3.7.9
 
 # set work directory
 WORKDIR /usr/src/app
@@ -21,39 +21,10 @@ WORKDIR /usr/src/app
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
-# required packages to install mysql
-# https://github.com/gliderlabs/docker-alpine/issues/181
-RUN apk add --no-cache mariadb-connector-c-dev ;\
-    apk add --no-cache --virtual .build-deps \
-        build-base \
-        mariadb-dev ;\
-    pip install mysqlclient;\
-    apk del .build-deps
-
-# Fix: Error loading shared library libstdc++.so.6: No such file or directory (needed by ./hubCheck)
-#      Error loading shared library libgcc_s.so.1: No such file or directory (needed by ./hubCheck)
-#      Error relocating /usr/src/app/tools/hubCheck: qsort_r: symbol not found
-# and many others (when running hubcheck $ ldd ./hubcheck)
-RUN apk update --no-cache && \
-    apk upgrade --no-cache && \
-    apk add --no-cache curl bash openssl libgcc libstdc++ ncurses-libs libc-dev patch g++ gcompat
-# download hubcheck utility
-RUN mkdir tools ;\
-    curl -o tools/hubCheck http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/hubCheck ;\
-    chmod u+x tools/hubCheck
-
-# Required alpine packages to install uWSGI server in order to run django app
-RUN apk add --update --no-cache --virtual .tmp gcc libc-dev linux-headers
-
 # copy our django project
 COPY . .
 # install dependencies
-#COPY ./requirements.txt .
 RUN pip install -r /usr/src/app/requirements.txt
-RUN apk del .tmp
-
-# copy entrypoint.sh
-#COPY ./entrypoint.sh /usr/src/app/entrypoint.sh
 
 # run entrypoint.sh
 RUN chmod +x /usr/src/app/entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,18 @@ RUN apk add --no-cache mariadb-connector-c-dev ;\
     pip install mysqlclient;\
     apk del .build-deps
 
+# Fix: Error loading shared library libstdc++.so.6: No such file or directory (needed by ./hubCheck)
+#      Error loading shared library libgcc_s.so.1: No such file or directory (needed by ./hubCheck)
+#      Error relocating /usr/src/app/tools/hubCheck: qsort_r: symbol not found
+# and many others (when running hubcheck $ ldd ./hubcheck)
+RUN apk update --no-cache && \
+    apk upgrade --no-cache && \
+    apk add --no-cache curl bash openssl libgcc libstdc++ ncurses-libs libc-dev patch g++ gcompat
+# download hubcheck utility
+RUN mkdir tools ;\
+    curl -o tools/hubCheck http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/hubCheck ;\
+    chmod u+x tools/hubCheck
+
 # Required alpine packages to install uWSGI server in order to run django app
 RUN apk add --update --no-cache --virtual .tmp gcc libc-dev linux-headers
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ cd thr
 You can run the whole application ([Frontend](https://github.com/Ensembl/thr_frontend) + [Backend](https://github.com/Ensembl/thr)) using docker-compose:
 
 
-Uncomment the last line in `Dockefile`
+Uncomment the last line in `Dockerfile`
 
 ```bash
 ENTRYPOINT ["/usr/src/app/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -210,19 +210,13 @@ python manage.py createsuperuser
 
 ##### Rebuilding and enriching Elasticsearch index (if required)
 
-In case we want to rebuild the ES index with data existing in MySQL, you need to:
+In case we want to rebuild the ES index with data existing in MySQL, you need to run the following command:
 
 1. Rebuild ES index
 ```shell script
-python manage.py search_index --rebuild -f
-```
-This will load portion of the data from MySQL to ES
-
-2. Run the `enrich` command that extract `configuration`, `data` and `file type` objects from MySQL DB and store it back in Elasticsearch by updating the documents.
-
-```shell script
 python manage.py enrich 
 ```
+This will rebuild the ES index (`python manage.py search_index --rebuild -f`) and extract `configuration`, `data` and `file type` objects from MySQL DB and store it back in Elasticsearch by updating the documents.
 
 ##### Setting up Cron job
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ cd thr
 
 You can run the whole application ([Frontend](https://github.com/Ensembl/thr_frontend) + [Backend](https://github.com/Ensembl/thr)) using docker-compose:
 
+
+Uncomment the last line in `Dockefile`
+
+```bash
+ENTRYPOINT ["/usr/src/app/entrypoint.sh"]
+```
+
+Then run
+
 ```shell script
 docker-compose -f docker-compose-local.yml up
 ```

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -14,9 +14,7 @@ services:
     env_file:
       - .env
     command: >
-      sh -c "python manage.py makemigrations &&
-             python manage.py migrate &&
-             # Build elasticsearch index
+      sh -c "# Build elasticsearch index
              sleep 20 &&
              python manage.py search_index --rebuild -f &&
              pwd && gunicorn thr.wsgi:application --bind 0.0.0.0:8000 --timeout 120"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,4 +27,9 @@ User = get_user_model();
 User.objects.filter(email='$DJANGO_ADMIN_EMAIL').delete();
 User.objects.create_superuser('$DJANGO_ADMIN_USER', '$DJANGO_ADMIN_EMAIL', '$DJANGO_ADMIN_PASSWORD')" | python manage.py shell
 
+# import the assembly dump
+python manage.py import_assemblies --fetch ena
+# and load it to MySQL DB
+python manage.py import_assemblies
+
 exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,6 +19,9 @@ find . -path "*/migrations/*.pyc"  -delete
 python manage.py makemigrations
 python manage.py migrate
 
+# build ES index
+python manage.py search_index --rebuild -f
+
 # create a superuser defined by the environment variables
 # Fix: 'Manager isn't available' error
 # https://stackoverflow.com/a/67530965/4488332

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,8 +12,11 @@ fi
 
 # create the static files to be used by the Django admin portal
 python manage.py collectstatic --noinput
+# find and delete any remaining migration files before creating new ones
+find . -path "*/migrations/*.py" -not -name "__init__.py" -delete
+find . -path "*/migrations/*.pyc"  -delete
 # migrate our current THR schema to the MySQL database
-python manage.py makemigration
+python manage.py makemigrations
 python manage.py migrate
 
 # create a superuser defined by the environment variables

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,7 @@ python manage.py search_index --rebuild -f
 
 # create a superuser defined by the environment variables
 # Fix: 'Manager isn't available' error
-# https://stackoverflow.com/a/67530965/4488332
+# https://stackoverflow.com/a/17874111
 echo "from django.contrib.auth import get_user_model;
 User = get_user_model();
 User.objects.filter(email='$DJANGO_ADMIN_EMAIL').delete();

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,10 @@ fi
 python manage.py collectstatic --noinput
 
 # create a superuser defined by the environment variables
-echo "from django.contrib.auth.models import User;
+# Fix: 'Manager isn't available' error
+# https://stackoverflow.com/a/67530965/4488332
+echo "from django.contrib.auth import get_user_model;
+User = get_user_model();
 User.objects.filter(email='$DJANGO_ADMIN_EMAIL').delete();
 User.objects.create_superuser('$DJANGO_ADMIN_USER', '$DJANGO_ADMIN_EMAIL', '$DJANGO_ADMIN_PASSWORD')" | python manage.py shell
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,6 +12,9 @@ fi
 
 # create the static files to be used by the Django admin portal
 python manage.py collectstatic --noinput
+# migrate our current THR schema to the MySQL database
+python manage.py makemigration
+python manage.py migrate
 
 # create a superuser defined by the environment variables
 # Fix: 'Manager isn't available' error

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,12 +23,7 @@ python manage.py migrate
 python manage.py search_index --rebuild -f
 
 # create a superuser defined by the environment variables
-# Fix: 'Manager isn't available' error
-# https://stackoverflow.com/a/17874111
-echo "from django.contrib.auth import get_user_model;
-User = get_user_model();
-User.objects.filter(email='$DJANGO_ADMIN_EMAIL').delete();
-User.objects.create_superuser('$DJANGO_ADMIN_USER', '$DJANGO_ADMIN_EMAIL', '$DJANGO_ADMIN_PASSWORD')" | python manage.py shell
+python manage.py create_superuser --username "$DJANGO_ADMIN_USER" --password "$DJANGO_ADMIN_PASSWORD" --noinput --email "$DJANGO_ADMIN_EMAIL"
 
 # import the assembly dump
 python manage.py import_assemblies --fetch ena

--- a/thr/settings/base.py
+++ b/thr/settings/base.py
@@ -133,12 +133,12 @@ AUTH_USER_MODEL = 'users.CustomUser'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.mysql',
-        'NAME': os.environ.get('THR_DB_NAME', 'thr_db'),
-        'USER': os.environ.get('THR_DB_USER', 'thr_dev'),
-        'PASSWORD': os.environ.get('THR_DB_PASSWORD', 'password'),
-        'HOST': os.environ.get('THR_HOST', 'mysql'),
-        'PORT': os.environ.get('THR_PORT', '3306'),
+        'ENGINE': os.environ.get('DB_ENGINE', 'django.db.backends.mysql'),
+        'NAME': os.environ.get('DB_DATABASE', 'thr_db'),
+        'USER': os.environ.get('DB_USER', 'thr_dev'),
+        'PASSWORD': os.environ.get('DB_PASSWORD', 'password'),
+        'HOST': os.environ.get('DB_HOST', 'mysql'),
+        'PORT': os.environ.get('DB_PORT', '3306'),
         'OPTIONS': {
             # Tell MySQLdb to connect with 'utf8mb4' character set
             'charset': 'utf8mb4',
@@ -155,7 +155,7 @@ ELASTICSEARCH_DSL = {
 
 # Name of the Elasticsearch index
 ELASTICSEARCH_INDEX_NAMES = {
-    'search.documents': 'trackhubs',
+    'search.documents': os.environ.get('ES_INDEX', 'trackhubs'),
 }
 
 # Password validation

--- a/thr/settings/base.py
+++ b/thr/settings/base.py
@@ -149,7 +149,7 @@ DATABASES = {
 ELASTICSEARCH_DSL = {
     'default': {
         'hosts': os.environ.get('ES_HOST', 'elasticsearch:9200'),
-        'timeout': 600,  # Custom timeout
+        'timeout': 60000,  # Custom timeout
     },
 }
 

--- a/thr/settings/dev.py
+++ b/thr/settings/dev.py
@@ -15,7 +15,6 @@
 # pylint: disable=wildcard-import
 from .base import *
 DEBUG = True
-ALLOWED_HOSTS = ['localhost', '127.0.0.1']
 
 # (CORS) Cross-Origin Resource Sharing Settings
 CORS_ORIGIN_ALLOW_ALL = True

--- a/trackdbs/serializers.py
+++ b/trackdbs/serializers.py
@@ -12,6 +12,7 @@
    limitations under the License.
 """
 from datetime import datetime
+from trackhubs.utils import str2obj
 
 from rest_framework import serializers
 from trackhubs import models
@@ -71,6 +72,8 @@ class TrackdbSerializer(serializers.ModelSerializer):
     hub = serializers.SerializerMethodField()
     species = serializers.SerializerMethodField()
     assembly = serializers.SerializerMethodField()
+    configuration = serializers.SerializerMethodField()
+    status = serializers.SerializerMethodField()
 
     class Meta:
         model = models.Trackdb
@@ -128,6 +131,14 @@ class TrackdbSerializer(serializers.ModelSerializer):
     def get_assembly(obj):
         assembly = models.Assembly.objects.filter(assembly_id=obj.assembly.assembly_id).first()
         return TrackdbAssemblySerializer(assembly).data
+
+    @staticmethod
+    def get_configuration(obj):
+        return str2obj(obj.configuration)
+
+    @staticmethod
+    def get_status(obj):
+        return str2obj(obj.status)
 
     @staticmethod
     def get_file_type(obj):

--- a/trackhubs/management/commands/enrich.py
+++ b/trackhubs/management/commands/enrich.py
@@ -31,7 +31,9 @@ class Command(BaseCommand):
             trackdb.update_trackdb_document(trackdb.hub, trackdb.data, trackdb.configuration, tracks_status)
 
     def handle(self, *args, **options):
-        management.call_command("search_index", "--rebuild", "-f")
+        # uncomment the line below if you want to rebuild and enrich the index at the same time
+        # it's commented because it takes time on k8s and keep causing timeout error
+        # management.call_command("search_index", "--rebuild", "-f")
         # the command below will enrich all trackdbs stored in the DB
         # e.g. python manage.py enrich
         self._enrich_docs()

--- a/trackhubs/management/commands/enrich.py
+++ b/trackhubs/management/commands/enrich.py
@@ -16,6 +16,7 @@ from django.core.management.base import BaseCommand
 
 from trackhubs.tracks_status import fetch_tracks_status
 import trackhubs.models
+from django.core import management
 
 
 class Command(BaseCommand):
@@ -30,6 +31,7 @@ class Command(BaseCommand):
             trackdb.update_trackdb_document(trackdb.hub, trackdb.data, trackdb.configuration, tracks_status)
 
     def handle(self, *args, **options):
+        management.call_command("search_index", "--rebuild", "-f")
         # the command below will enrich all trackdbs stored in the DB
         # e.g. python manage.py enrich
         self._enrich_docs()

--- a/trackhubs/models.py
+++ b/trackhubs/models.py
@@ -22,8 +22,10 @@ from django_elasticsearch_dsl_drf.wrappers import dict_to_obj
 from django_mysql.models import JSONField
 import elasticsearch
 from elasticsearch_dsl import connections
-from users.models import CustomUser as User
+from django.contrib.auth import get_user_model
 import trackhubs
+
+User = get_user_model()
 
 logger = logging.getLogger(__name__)
 

--- a/trackhubs/models.py
+++ b/trackhubs/models.py
@@ -22,10 +22,8 @@ from django_elasticsearch_dsl_drf.wrappers import dict_to_obj
 from django_mysql.models import JSONField
 import elasticsearch
 from elasticsearch_dsl import connections
-from django.contrib.auth import get_user_model
+from users.models import CustomUser as User
 import trackhubs
-
-User = get_user_model()
 
 logger = logging.getLogger(__name__)
 
@@ -54,7 +52,7 @@ class FileType(models.Model):
 
     file_type_id = models.AutoField(primary_key=True)
     name = models.CharField(max_length=100)
-    settings = JSONField()
+    settings = models.TextField(null=True)  # JSONField()
 
 
 class Visibility(models.Model):
@@ -181,9 +179,9 @@ class Trackdb(models.Model):
     version = models.CharField(default="v1.0", max_length=10)
     created = models.IntegerField(default=int(time.time()))
     updated = models.IntegerField(null=True)
-    configuration = JSONField()
-    data = JSONField()
-    status = JSONField()
+    configuration = models.TextField(null=True)  # JSONField()
+    data = models.TextField(null=True)  # JSONField()
+    status = models.TextField(null=True)  # JSONField()
     source_url = models.CharField(max_length=255, null=True)
     source_checksum = models.CharField(max_length=255, null=True)
     assembly = models.ForeignKey(Assembly, on_delete=models.CASCADE)
@@ -327,7 +325,7 @@ class Track(models.Model):
     big_data_url = models.CharField(max_length=255, null=True)
     html = models.CharField(max_length=255, null=True)
     meta = models.CharField(max_length=255, null=True)
-    additional_properties = JSONField()
+    additional_properties = models.TextField(null=True)  # JSONField()
     composite_parent = models.CharField(max_length=2, null=True)
     parent = models.ForeignKey('self', null=True, on_delete=models.CASCADE)
     trackdb = models.ForeignKey(Trackdb, on_delete=models.CASCADE)

--- a/trackhubs/models.py
+++ b/trackhubs/models.py
@@ -24,8 +24,7 @@ import elasticsearch
 from elasticsearch_dsl import connections
 from users.models import CustomUser as User
 import trackhubs
-from trackhubs.utils import str2obj
-
+from .utils import str2obj
 logger = logging.getLogger(__name__)
 
 

--- a/trackhubs/models.py
+++ b/trackhubs/models.py
@@ -24,7 +24,7 @@ import elasticsearch
 from elasticsearch_dsl import connections
 from users.models import CustomUser as User
 import trackhubs
-from .utils import str2obj
+from trackhubs.utils import str2obj
 logger = logging.getLogger(__name__)
 
 

--- a/trackhubs/tests/test_utils.py
+++ b/trackhubs/tests/test_utils.py
@@ -1,0 +1,37 @@
+"""
+.. See the NOTICE file distributed with this work for additional information
+   regarding copyright ownership.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+"""
+
+import pytest
+import trackhubs.utils
+
+
+@pytest.mark.parametrize(
+    'the_string, expected_output, expected_type',
+    [
+        ("{}", {}, dict),
+        ("{'a': 'b'}", {'a': 'b'}, dict),
+        ("{'a': {'b': [11, 12]}}", {'a': {'b': [11, 12]}}, dict),
+        ("{1: 1, 2: 4}", {'1': 1, '2': 4}, dict),
+        ("[]", [], list),
+        ("['a', 11, True]", ['a', 11, True], list),
+        ("['a', [11, True], 44]", ['a', [11, True], 44], list),
+        ("foo", None, type(None)),
+        (1, None, type(None)),
+        (None, None, type(None)),
+    ]
+)
+def test_str2obj(the_string, expected_output, expected_type):
+    actual_output = trackhubs.utils.str2obj(the_string)
+    assert actual_output == expected_output
+    assert isinstance(actual_output, expected_type)

--- a/trackhubs/tests/test_utils.py
+++ b/trackhubs/tests/test_utils.py
@@ -29,6 +29,10 @@ import trackhubs.utils
         ("foo", None, type(None)),
         (1, None, type(None)),
         (None, None, type(None)),
+        ({}, {}, dict),
+        ({'a': {'b': [11, 12]}}, {'a': {'b': [11, 12]}}, dict),
+        ([], [], list),
+        (['a', [11, True], 44], ['a', [11, True], 44], list),
     ]
 )
 def test_str2obj(the_string, expected_output, expected_type):

--- a/trackhubs/tests/test_utils.py
+++ b/trackhubs/tests/test_utils.py
@@ -33,6 +33,8 @@ import trackhubs.utils
         ({'a': {'b': [11, 12]}}, {'a': {'b': [11, 12]}}, dict),
         ([], [], list),
         (['a', [11, True], 44], ['a', [11, True], 44], list),
+        ("'a'", None, type(None)),
+        ("'1'", None, type(None)),
     ]
 )
 def test_str2obj(the_string, expected_output, expected_type):

--- a/trackhubs/translator.py
+++ b/trackhubs/translator.py
@@ -407,10 +407,15 @@ def save_and_update_document(hub_url, data_type, current_user):
                     )
 
                     # if the track is parent we prepare the configuration object
-                    if any(k in track for k in ('compositeTrack', 'superTrack', 'container')):
-                        # logger.debug("'{}' is parent".format(track['track']))
-                        trackdb_configuration[track['track']] = track
-                        trackdb_configuration[track['track']].pop('url', None)
+                    # if any(k in track for k in ('compositeTrack', 'superTrack', 'container')):
+                    # logger.debug("'{}' is parent".format(track['track']))
+
+                    # prepare the configuration object
+                    # the if above commented out because regardless of whether the track is a parent or not
+                    # this fix seems to work, but looks too good to be true, however I can't see any side effect
+                    # the commented if above is left there just in case if it turns out I need it in the future
+                    trackdb_configuration[track['track']] = track
+                    trackdb_configuration[track['track']].pop('url', None)
 
                     # if the track is a child, add the parent id and update
                     # the configuration to include the current track

--- a/trackhubs/translator.py
+++ b/trackhubs/translator.py
@@ -17,7 +17,7 @@ import logging
 import time
 
 import django
-from users.models import CustomUser as User
+from django.contrib.auth import get_user_model
 
 import trackhubs
 from trackhubs.constants import DATA_TYPES, FILE_TYPES, VISIBILITY
@@ -25,6 +25,8 @@ from trackhubs.hub_check import hub_check
 from trackhubs.models import Trackdb, GenomeAssemblyDump
 from trackhubs.parser import parse_file_from_url
 from trackhubs.tracks_status import fetch_tracks_status, fix_big_data_url
+
+User = get_user_model()
 
 logger = logging.getLogger(__name__)
 

--- a/trackhubs/utils.py
+++ b/trackhubs/utils.py
@@ -1,0 +1,18 @@
+import ast
+import json
+
+
+def str2obj(var):
+    """
+    Convert string dict/array to an actual dict/array
+    this function is used to convert trackdb_configuration
+    and trackdb_data from string (as stored in MySQL) to JSON
+    (as it need for it to be stored in Elasticsearch when enriching the document)
+    :returns: JSON object
+    """
+    if isinstance(var, dict) or isinstance(var, list):
+        return var
+
+    var = ast.literal_eval(var)
+    string_var_double_quote = json.dumps(var)
+    return json.loads(string_var_double_quote)

--- a/trackhubs/utils.py
+++ b/trackhubs/utils.py
@@ -1,5 +1,8 @@
 import ast
 import json
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def str2obj(var):
@@ -13,6 +16,13 @@ def str2obj(var):
     if isinstance(var, dict) or isinstance(var, list):
         return var
 
-    var = ast.literal_eval(var)
+    try:
+        var = ast.literal_eval(var)
+    # if the result of ast.literal_eval is not a dict or array
+    # print the error and return None
+    except ValueError as ex:
+        logger.error(ex)
+        return None
+
     string_var_double_quote = json.dumps(var)
     return json.loads(string_var_double_quote)

--- a/trackhubs/utils.py
+++ b/trackhubs/utils.py
@@ -24,5 +24,11 @@ def str2obj(var):
         logger.error(ex)
         return None
 
+    # Take into account values that are not lists/dicts of strings
+    # and don't cause ValueErrors, for example ast.literal_eval("'a'") evaluates to 'a',
+    # and ast.literal_eval("1") evaluates to 1
+    if not (isinstance(var, list) or isinstance(var, dict)):
+        return None
+
     string_var_double_quote = json.dumps(var)
     return json.loads(string_var_double_quote)

--- a/users/admin.py
+++ b/users/admin.py
@@ -14,6 +14,8 @@
 
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
-from .models import CustomUser
+from django.contrib.auth import get_user_model
 
-admin.site.register(CustomUser, UserAdmin)
+User = get_user_model()
+
+admin.site.register(User, UserAdmin)

--- a/users/management/commands/create_superuser.py
+++ b/users/management/commands/create_superuser.py
@@ -1,0 +1,43 @@
+"""
+.. See the NOTICE file distributed with this work for additional information
+   regarding copyright ownership.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+"""
+
+from django.contrib.auth.management.commands import createsuperuser
+from django.core.management import CommandError
+
+
+# stole it from this SO answer: https://stackoverflow.com/a/42491469/4488332
+class Command(createsuperuser.Command):
+    help = 'Crate a superuser, and allow password to be provided'
+
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument(
+            '--password', dest='password', default=None,
+            help='Specifies the password for the superuser.',
+        )
+
+    def handle(self, *args, **options):
+        password = options.get('password')
+        username = options.get('username')
+        database = options.get('database')
+
+        if password and not username:
+            raise CommandError("--username is required if specifying --password")
+
+        super(Command, self).handle(*args, **options)
+
+        if password:
+            user = self.UserModel._default_manager.db_manager(database).get(username=username)
+            user.set_password(password)
+            user.save()

--- a/users/management/commands/import_users.py
+++ b/users/management/commands/import_users.py
@@ -15,10 +15,11 @@
 import json
 import time
 
-from users.models import CustomUser as User
+from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
 from argparse import RawTextHelpFormatter
 
+User = get_user_model()
 
 def import_users_dump(filepath):
     """

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -14,11 +14,13 @@
 
 from rest_framework import serializers
 from django.contrib.auth import password_validation
-from users.models import CustomUser as User
+from django.contrib.auth import get_user_model
 
 from django.contrib.auth.tokens import PasswordResetTokenGenerator
 from django.utils.encoding import smart_str, force_str, smart_bytes, DjangoUnicodeDecodeError
 from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
+
+User = get_user_model()
 
 
 class RegistrationSerializer(serializers.ModelSerializer):

--- a/users/views.py
+++ b/users/views.py
@@ -21,7 +21,7 @@ from rest_framework.generics import UpdateAPIView
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from users.models import CustomUser as User
+from django.contrib.auth import get_user_model
 from users.serializers import RegistrationSerializer, CustomUserSerializer, ChangePasswordSerializer, \
     ResetPasswordEmailSerializer, SetNewPasswordSerializer
 
@@ -29,6 +29,8 @@ from django.contrib.auth.tokens import PasswordResetTokenGenerator
 from django.utils.encoding import smart_str, force_str, smart_bytes, DjangoUnicodeDecodeError
 from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
 from django.core.mail import send_mail
+
+User = get_user_model()
 
 
 class RegistrationViewAPI(APIView):


### PR DESCRIPTION
Kept getting this error when running docker image:
```
$ docker run -p 80:80 -it thr_django

152 static files copied to '/usr/src/app/thr/static'.
Traceback (most recent call last):
  File "manage.py", line 36, in <module>
    main()
  File "manage.py", line 32, in main
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python3.7/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.7/site-packages/django/core/management/__init__.py", line 375, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python3.7/site-packages/django/core/management/base.py", line 323, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/local/lib/python3.7/site-packages/django/core/management/base.py", line 364, in execute
    output = self.handle(*args, **options)
  File "/usr/local/lib/python3.7/site-packages/django/core/management/commands/shell.py", line 92, in handle
    exec(sys.stdin.read())
  File "<string>", line 2, in <module>
  File "/usr/local/lib/python3.7/site-packages/django/db/models/manager.py", line 188, in __get__
    cls._meta.swapped,
AttributeError: Manager isn't available; 'auth.User' has been swapped for 'users.CustomUser'
```
This branch fixes the issue ([the exact commit](https://github.com/Ensembl/thr/pull/31/commits/486195a3ffd19548dfd80e709eff0f03e0b296b7)).

-------

Replaced JSON Fields with LONGTEXT to support MySQL 6

-------

Jira tasks:
* https://www.ebi.ac.uk/panda/jira/browse/EA-814
* https://www.ebi.ac.uk/panda/jira/browse/EA-834
* https://www.ebi.ac.uk/panda/jira/browse/EA-833
* https://www.ebi.ac.uk/panda/jira/browse/EA-806