### PR TITLE
Add warning message to GET endpoints for login and logout

### DIFF
--- a/apis_endpoints_status.md
+++ b/apis_endpoints_status.md
@@ -5,9 +5,11 @@
 | Endpoint name                   | Description                                                | Status      |
 | ------------------------------- | ---------------------------------------------------------- | ----------- |
 | POST /api/user                  | Get information about the current user                     | Done        |
-| POST /api/user/register         | Register a new user and obtain the access token            | Done        |
-| POST /api/user/login            | Login and get the authentication token                     | Done        |
-| POST /api/user/logout           | Logout and invalidate the current access token             | Done        |
+| POST /api/register              | Register a new user and obtain the access token            | Done        |
+| POST /api/login                 | Login and get the authentication token (POST)              | Done        |
+| GET  /api/login                 | Login and get the authentication token  (GET)              | Done        |
+| POST /api/logout                | Logout and invalidate the current access token (POST)      | Done        |
+| GET /api/logout                 | Logout and invalidate the current access token (GET)       | Done        |
 | GET /api/trackhub               | Returns the set of registered track data hubs for the given user| Done   |
 | GET /api/trackhub/:id           | Return a track hub with the given name in the Registry     | Done        |
 | DELETE /api/trackhub/:id        | Delete trackDBs assigned to a given track hub              | Done        |

--- a/apis_endpoints_status.md
+++ b/apis_endpoints_status.md
@@ -6,10 +6,8 @@
 | ------------------------------- | ---------------------------------------------------------- | ----------- |
 | POST /api/user                  | Get information about the current user                     | Done        |
 | POST /api/register              | Register a new user and obtain the access token            | Done        |
-| POST /api/login                 | Login and get the authentication token (POST)              | Done        |
-| GET  /api/login                 | Login and get the authentication token  (GET)              | Done        |
-| POST /api/logout                | Logout and invalidate the current access token (POST)      | Done        |
-| GET /api/logout                 | Logout and invalidate the current access token (GET)       | Done        |
+| POST /api/login                 | Login and get the authentication token                     | Done        |
+| POST /api/logout                | Logout and invalidate the current access token             | Done        |
 | GET /api/trackhub               | Returns the set of registered track data hubs for the given user| Done   |
 | GET /api/trackhub/:id           | Return a track hub with the given name in the Registry     | Done        |
 | DELETE /api/trackhub/:id        | Delete trackDBs assigned to a given track hub              | Done        |

--- a/thr/settings/base.py
+++ b/thr/settings/base.py
@@ -269,4 +269,7 @@ BACKEND_URL = os.environ.get('BACKEND_URL', 'localhost:8000')
 # and Hub facets can be controlled using FACETS_LENGHT
 FACETS_LENGHT = 30
 
+# The hub check API is in a separate VM
+HUBCHECK_API_URL = os.environ.get('HUBCHECK_API_URL', 'http://localhost:8888/hubcheck')
+
 THR_VERSION = "0.8"

--- a/trackhubs/hub_check.py
+++ b/trackhubs/hub_check.py
@@ -14,6 +14,7 @@
 
 import sys
 import requests
+from thr import settings
 
 
 def hub_check(hub_url):
@@ -23,7 +24,7 @@ def hub_check(hub_url):
     :returns: the hub information if the submission was successful otherwise it returns an error
     TODO: group 'translator.py', 'hub_check.py', 'constants' and 'parser.py' in 'utils' directory
     """
-    url = "http://wp-p1m-b9:8000/hubcheck"
+    url = settings.HUBCHECK_API_URL
     payload = {"hub_url": hub_url}
 
     print("[INFO] Checking " + hub_url + "...")

--- a/trackhubs/hub_check.py
+++ b/trackhubs/hub_check.py
@@ -12,69 +12,25 @@
    limitations under the License.
 """
 
-import subprocess
-from pathlib import Path
-from sys import platform
+import sys
+import requests
 
 
 def hub_check(hub_url):
     """
-    Runs the USCS hubCheck tool on the submitted hub
+    Runs the USCS hubCheck API on the submitted hub
     :param hub_url: the hub url provided by the submitter
     :returns: the hub information if the submission was successful otherwise it returns an error
     TODO: group 'translator.py', 'hub_check.py', 'constants' and 'parser.py' in 'utils' directory
     """
-    # replacing 'file:///' by 'local:' to avoid 'Unrecognized protocol file in udcProtNew' error
-    hub_url = hub_url.replace('file:///', 'local:')
-    # Download hubCheck if it doesn't exist in 'tools' directory (in the project root dir) and make it executable
-    hubcheck = Path("tools/hubCheck")
-    if not Path(hubcheck).exists():
-        # consider the OS used and download the appropriate one accordingly
-        if platform == "linux":
-            subprocess.run(
-                ["curl", "-o", "tools/hubCheck", "http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/hubCheck"]
-            )
-        elif platform == "darwin":
-            subprocess.run(
-                ["curl", "-o", "tools/hubCheck", "http://hgdownload.soe.ucsc.edu/admin/exe/macOSX.x86_64/hubCheck"]
-            )
-
-        hubcheck.chmod(0o700)
+    url = "http://wp-p1m-b9:8000/hubcheck"
+    payload = {"hub_url": hub_url}
 
     print("[INFO] Checking " + hub_url + "...")
-    hub_check_result = subprocess.run(
-        ["tools/hubCheck", "-noTracks", hub_url],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        universal_newlines=True
-    )
-    print(hub_check_result)
+    response = requests.get(url, params=payload)
+    if not response.ok:
+        print("Couldn't run hubCheck, reason: %s [%d]" % (response.text, response.status_code))
+        sys.exit()
 
-    # hubCheck exits with code 1 even if there are only warnings
-    # to fix that, we ignore warning except if an error occurs.
-    error = False
-    warnings = False
-    if hub_check_result.returncode:
-        line_0 = hub_check_result.stdout.splitlines()[0]
-        other_lines = hub_check_result.stdout.splitlines()[1:]
-        for line in other_lines:  # we skip the first line
-            if not line.startswith("warning:"):
-                error = True
-            else:
-                warnings = True
-
-    if warnings:
-        return {
-            'warning': 'Warnings found (they can be ignored)',
-            'details': list(war for war in other_lines)
-        }
-
-    if error:
-        return {
-            'error': 'Error in hub {}: {}'.format(hub_url, line_0.strip(':')),
-            'details': list(err for err in other_lines)
-        }
-
-    return {
-        'success': 'hubCheck done! Nothing to report!'
-    }
+    hub_check_result = response.json()
+    return hub_check_result

--- a/trackhubs/tests/test_hub_check.py
+++ b/trackhubs/tests/test_hub_check.py
@@ -25,9 +25,9 @@ def project_dir():
 @pytest.mark.parametrize(
     'test_hub_url, expected_key_in_result',
     [
-        ('local:' + str(BASE_DIR.parent) + '/' + 'samples/JASPAR_TFBS/hub.txt', 'success'),
-        ('local:' + str(BASE_DIR.parent) + '/' + 'samples/SRP066358/hub.txt', 'warning'),
-        ('local:' + str(BASE_DIR.parent) + '/' + 'samples/not/here/hub.txt', 'error'),
+        ('ftp://ftp.ebi.ac.uk/pub/databases/Rfam/12.0/genome_browser_hub/hub.txt', 'success'),
+        ('ftp://ftp.ensemblgenomes.org/pub/misc_data/Track_Hubs/SRP090583/hub.txt', 'warning'),
+        ('ftp://ftp.ebi.ac.uk/pub/databases/not/here/hub.txt', 'error'),
     ]
 )
 def test_hub_check_all_cases(test_hub_url, expected_key_in_result):

--- a/trackhubs/tests/test_utils.py
+++ b/trackhubs/tests/test_utils.py
@@ -13,7 +13,7 @@
 """
 
 import pytest
-from trackhubs.utils import str2obj, escape_ansi
+from trackhubs.utils import str2obj, escape_ansi, remove_html_tags
 
 
 
@@ -68,5 +68,5 @@ def test_escape_ansi(string_line, expected_result):
     ]
 )
 def test_remove_html_tags(html_text, expected_result):
-    actual_result = trackhubs.utils.remove_html_tags(html_text)
+    actual_result = remove_html_tags(html_text)
     assert actual_result == expected_result

--- a/trackhubs/translator.py
+++ b/trackhubs/translator.py
@@ -331,9 +331,9 @@ def save_and_update_document(hub_url, data_type, current_user):
 
     # TODO: add the possibility for the user to disable/enable hubCheck when submitting new Hub(s)
     # run the USCS hubCheck tool found in kent tools on the submitted hub
-    # hub_check_result = hub_check(hub_url)
-    # if 'error' in hub_check_result.keys():
-    #     return hub_check_result
+    hub_check_result = hub_check(hub_url)
+    if 'error' in hub_check_result.keys():
+        return hub_check_result
 
     hub_info_array = parse_file_from_url(hub_url)
 

--- a/users/tests.py
+++ b/users/tests.py
@@ -25,7 +25,7 @@ from thr import settings
 
 
 @pytest.mark.django_db
-def test_login_success(api_client, django_user_model):
+def test_post_login_success(api_client, django_user_model):
     """
     Test user login
     :param api_client: the API client
@@ -53,7 +53,7 @@ def test_login_success(api_client, django_user_model):
     ]
 )
 @pytest.mark.django_db
-def test_login_fail(username, password, status_code, api_client):
+def test_post_login_fail(username, password, status_code, api_client):
     """
     Test user login failure when the provided credential aren't correct
     """
@@ -67,7 +67,7 @@ def test_login_fail(username, password, status_code, api_client):
 
 
 @pytest.mark.django_db
-def test_logout_success(api_client, django_user_model):
+def test_post_logout_success(api_client, django_user_model):
     """
     Log the user in and out while providing the access token
     """
@@ -80,7 +80,75 @@ def test_logout_success(api_client, django_user_model):
 
 
 @pytest.mark.django_db
-def test_logout_fail(api_client):
+def test_post_logout_fail(api_client):
+    """
+    Log the user in and out while providing the access token
+    """
+    token = 'random14token77definitely895invalid'
+    api_client.credentials(HTTP_AUTHORIZATION='Token ' + token)
+    url = reverse('logout_api')
+    response = api_client.post(url)
+    assert response.status_code == 401
+
+
+
+@pytest.mark.django_db
+def test_get_login_success(api_client, django_user_model):
+    """
+    Test user login
+    :param api_client: the API client
+    :param django_user_model: a shortcut to the User model configured for use by the
+    current Django project
+    """
+    username = 'user'
+    password = 'password'
+    django_user_model.objects.create_user(username=username, password=password)
+    url = reverse('login_api')
+    data = {
+        'username': username,
+        'password': password
+    }
+    response = api_client.post(url, data=data)
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'username, password, status_code', [
+        ('', '', 400),
+        ('', 'pass', 400),
+        ('non_existing_user', 'pass', 400),
+    ]
+)
+@pytest.mark.django_db
+def test_get_login_fail(username, password, status_code, api_client):
+    """
+    Test user login failure when the provided credential aren't correct
+    """
+    url = reverse('login_api')
+    data = {
+        'username': username,
+        'password': password
+    }
+    response = api_client.get(url, data=data)
+    assert response.status_code == status_code
+
+
+@pytest.mark.django_db
+def test_get_logout_success(api_client, django_user_model):
+    """
+    Log the user in and out while providing the access token
+    """
+    user = django_user_model.objects.create_user(username='user', password='password')
+    token, _ = Token.objects.get_or_create(user=user)
+    api_client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
+    url = reverse('logout_api')
+    response = api_client.get(url)
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_get_logout_fail(api_client):
     """
     Log the user in and out while providing the access token
     """

--- a/users/tests.py
+++ b/users/tests.py
@@ -93,7 +93,7 @@ def test_post_logout_fail(api_client):
 
 
 @pytest.mark.django_db
-def test_get_login_success(api_client, django_user_model):
+def test_get_login_existing_user(api_client, django_user_model):
     """
     Test user login
     :param api_client: the API client
@@ -108,20 +108,20 @@ def test_get_login_success(api_client, django_user_model):
         'username': username,
         'password': password
     }
-    response = api_client.post(url, data=data)
-    assert response.status_code == 200
+    response = api_client.get(url, data=data)
+    assert response.status_code == 301
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     'username, password, status_code', [
-        ('', '', 400),
-        ('', 'pass', 400),
-        ('non_existing_user', 'pass', 400),
+        ('', '', 301),
+        ('', 'pass', 301),
+        ('non_existing_user', 'pass', 301),
     ]
 )
 @pytest.mark.django_db
-def test_get_login_fail(username, password, status_code, api_client):
+def test_get_login_non_existing_user(username, password, status_code, api_client):
     """
     Test user login failure when the provided credential aren't correct
     """
@@ -135,7 +135,7 @@ def test_get_login_fail(username, password, status_code, api_client):
 
 
 @pytest.mark.django_db
-def test_get_logout_success(api_client, django_user_model):
+def test_get_logout_existing_user(api_client, django_user_model):
     """
     Log the user in and out while providing the access token
     """
@@ -144,18 +144,18 @@ def test_get_logout_success(api_client, django_user_model):
     api_client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
     url = reverse('logout_api')
     response = api_client.get(url)
-    assert response.status_code == 200
+    assert response.status_code == 301
 
 
 @pytest.mark.django_db
-def test_get_logout_fail(api_client):
+def test_get_logout_non_existing_user(api_client):
     """
     Log the user in and out while providing the access token
     """
     token = 'random14token77definitely895invalid'
     api_client.credentials(HTTP_AUTHORIZATION='Token ' + token)
     url = reverse('logout_api')
-    response = api_client.post(url)
+    response = api_client.get(url)
     assert response.status_code == 401
 
 

--- a/users/views.py
+++ b/users/views.py
@@ -45,9 +45,9 @@ User = get_user_model()
 
 class LoginViewAPI(ObtainAuthToken):
     """
-    To keep everyone happy we have both GET and POST for login
-    GET: same as THR legacy docs
-    POST: best practices + used by the frontend
+    We have both GET and POST for login
+    GET: Returns a message letting the user know this endpoint is replace with POST
+    POST: Returns the authentication token along with the user's email and whether their account is activated or not
     """
     def post(self, request, *args, **kwargs):
         """

--- a/users/views.py
+++ b/users/views.py
@@ -66,10 +66,13 @@ class LoginViewAPI(ObtainAuthToken):
 
     def get(self, request):
         """
-        Login by default uses POST, however, for consistencies reasons with THR legacy
-        GET request is added below which is a POST in disguise ¯\_(ツ)_/¯
+        Let the user know that GET endpoint is replaced with POST
         """
-        return self.post(request)
+        return Response(
+            {"Error": "GET API endpoint is being removed, please use POST instead "
+                      "(See the documentation for more details)"},
+            status.HTTP_301_MOVED_PERMANENTLY
+        )
 
 
 class RegistrationViewAPI(APIView):
@@ -154,9 +157,13 @@ class LogoutViewAPI(APIView):
 
     def get(self, request):
         """
-        Same as the Login API above, GET is added for consistencies reasons with THR legacy
+        Let the user know that GET endpoint is replaced with POST
         """
-        return self.post(request)
+        return Response(
+            {"Error": "GET API endpoint is being removed, please use POST instead "
+                      "(See the documentation for more details)"},
+            status.HTTP_301_MOVED_PERMANENTLY
+        )
 
 
 class UserDetailsView(APIView):

--- a/users/views.py
+++ b/users/views.py
@@ -67,17 +67,9 @@ class LoginViewAPI(ObtainAuthToken):
     def get(self, request):
         """
         Login by default uses POST, however, for consistencies reasons with THR legacy
-        GET request is added below
+        GET request is added below which is a POST in disguise ¯\_(ツ)_/¯
         """
-        serializer = self.serializer_class(data=request.data, context={'request': request})
-        serializer.is_valid(raise_exception=True)
-        user = serializer.validated_data['user']
-        token, created = Token.objects.get_or_create(user=user)
-        return Response({
-            'auth_token': token.key,
-            'email': user.email,
-            'is_account_activated': user.is_account_activated
-        })
+        return self.post(request)
 
 
 class RegistrationViewAPI(APIView):
@@ -164,9 +156,7 @@ class LogoutViewAPI(APIView):
         """
         Same as the Login API above, GET is added for consistencies reasons with THR legacy
         """
-        request.user.auth_token.delete()
-        logout(request)
-        return Response({"success": "Successfully logged out."}, status.HTTP_200_OK)
+        return self.post(request)
 
 
 class UserDetailsView(APIView):


### PR DESCRIPTION
https://www.ebi.ac.uk/panda/jira/browse/EA-1000

### Changes

After discussing with the team, Alexey and Akshatha we agreed to add GET endpoint warning letting the users know that GET is not supported anymore and is replace with POST

When the user try to login/logout using GET they'll see the following error:
```
{
   "Error": "GET API endpoint is being removed, please use POST instead (See the documentation for more details)"
}
```