### PR TITLE
Fix Ensembl search

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -107,7 +107,7 @@ def create_trackhub_resource(project_dir, api_client, create_user_resource, crea
         # 'url': 'file:///' + str(project_dir) + '/' + 'samples/JASPAR_TFBS/hub.txt'
         'url': 'https://raw.githubusercontent.com/Ensembl/thr/master/samples/JASPAR_TFBS/hub.txt'
     }
-    response = api_client.post('/api/trackhub/', submitted_hub, format='json')
+    response = api_client.post('/api/trackhub', submitted_hub, format='json')
     return response
 
 

--- a/info/urls.py
+++ b/info/urls.py
@@ -17,11 +17,11 @@ from django.urls import path
 from info import views
 
 urlpatterns = [
-    path('version', views.VersionInfoView.as_view()),
-    path('ping', views.PingInfoView.as_view()),
-    path('species', views.SpeciesInfoView.as_view()),
-    path('assemblies', views.AssembliesInfoView.as_view()),
-    path('hubs_per_assembly/<str:assembly>', views.HubPerAssemblyInfoView.as_view()),
-    path('tracks_per_assembly/<str:assembly>', views.TracksPerAssemblyInfoView.as_view()),
-    path('trackhubs', views.TrackhubsInfoView.as_view()),
+    path('/version', views.VersionInfoView.as_view()),
+    path('/ping', views.PingInfoView.as_view()),
+    path('/species', views.SpeciesInfoView.as_view()),
+    path('/assemblies', views.AssembliesInfoView.as_view()),
+    path('/hubs_per_assembly/<str:assembly>', views.HubPerAssemblyInfoView.as_view()),
+    path('/tracks_per_assembly/<str:assembly>', views.TracksPerAssemblyInfoView.as_view()),
+    path('/trackhubs', views.TrackhubsInfoView.as_view()),
 ]

--- a/search/tests.py
+++ b/search/tests.py
@@ -50,7 +50,7 @@ def test_post_search_fail(api_client, query_body, expected_error_message, create
 """
 
 def test_get_one_trackdb_success(api_client, create_track_resource):
-    response = api_client.get('/api/search/trackdb/1/')
+    response = api_client.get('/api/search/trackdb/1')
     actual_result = response.json()
     assert actual_result['trackdb_id'] == 1
     assert response.status_code == 200
@@ -58,7 +58,7 @@ def test_get_one_trackdb_success(api_client, create_track_resource):
 
 def test_get_one_trackdb_fail(api_client):
     expected_result = {'error': 'TrackDB document not found.'}
-    response = api_client.get('/api/search/trackdb/1234567/')
+    response = api_client.get('/api/search/trackdb/1234567')
     actual_result = response.json()
     assert response.status_code == 404
     assert actual_result == expected_result

--- a/search/urls.py
+++ b/search/urls.py
@@ -18,5 +18,5 @@ from search.views import TrackdbDocumentDetailView, TrackdbDocumentListView
 
 urlpatterns = [
     path('', TrackdbDocumentListView.as_view({'post': 'list'})),
-    path('trackdb/<int:pk>/', TrackdbDocumentDetailView.as_view()),
+    path('/trackdb/<int:pk>', TrackdbDocumentDetailView.as_view()),
 ]

--- a/search/views.py
+++ b/search/views.py
@@ -128,6 +128,11 @@ class CustomPageNumberPagination(PageNumberPagination):
     'results' becomes 'items' and
     'count' becomes 'total_entries'
     """
+    # override page_size_query_param attribute
+    # http://localhost:8000/api/search?page=1&entries_per_page=3
+    # will return 3 items per page. If we don't provide 'entries_per_page'
+    # argument in the URL, DRF will use settings.PAGE_SIZE
+    page_size_query_param = 'entries_per_page'
 
     def get_paginated_response(self, data):
         # we catch the data and rename the fields on the fly before passing the response

--- a/stats/urls.py
+++ b/stats/urls.py
@@ -17,6 +17,6 @@ from django.urls import path
 from stats import views
 
 urlpatterns = [
-    path('summary', views.SummaryStatsView.as_view()),
-    path('complete', views.CompleteStatsView.as_view()),
+    path('/summary', views.SummaryStatsView.as_view()),
+    path('/complete', views.CompleteStatsView.as_view()),
 ]

--- a/thr/settings/base.py
+++ b/thr/settings/base.py
@@ -275,4 +275,4 @@ HUBCHECK_API_URL = os.environ.get('HUBCHECK_API_URL', 'http://localhost:8888/hub
 # Whether to append trailing slashes to URLs.
 APPEND_SLASH = False
 
-THR_VERSION = "0.8"
+THR_VERSION = "0.8.1"

--- a/thr/settings/base.py
+++ b/thr/settings/base.py
@@ -272,4 +272,7 @@ FACETS_LENGHT = 30
 # The hub check API is in a separate VM
 HUBCHECK_API_URL = os.environ.get('HUBCHECK_API_URL', 'http://localhost:8888/hubcheck')
 
+# Whether to append trailing slashes to URLs.
+APPEND_SLASH = False
+
 THR_VERSION = "0.8"

--- a/thr/urls.py
+++ b/thr/urls.py
@@ -38,9 +38,9 @@ urlpatterns = [
     # REST Framework URLs
     # path('api-auth/', include('rest_framework.urls')),
     path('api/', include('users.urls')),
-    path('api/trackhub/', include('trackhubs.urls')),
+    path('api/trackhub', include('trackhubs.urls')),
     path('api/search', include('search.urls')),
-    path('api/trackdb/', include('trackdbs.urls')),
-    path('api/info/', include('info.urls')),
-    path('api/stats/', include('stats.urls')),
+    path('api/trackdb', include('trackdbs.urls')),
+    path('api/info', include('info.urls')),
+    path('api/stats', include('stats.urls')),
 ]

--- a/thr/urls.py
+++ b/thr/urls.py
@@ -39,7 +39,7 @@ urlpatterns = [
     # path('api-auth/', include('rest_framework.urls')),
     path('api/', include('users.urls')),
     path('api/trackhub/', include('trackhubs.urls')),
-    path('api/search/', include('search.urls')),
+    path('api/search', include('search.urls')),
     path('api/trackdb/', include('trackdbs.urls')),
     path('api/info/', include('info.urls')),
     path('api/stats/', include('stats.urls')),

--- a/trackdbs/tests.py
+++ b/trackdbs/tests.py
@@ -16,12 +16,12 @@ import pytest
 
 
 def test_get_trackdb_without_login(api_client, create_trackhub_resource):
-    response = api_client.get('/api/trackdb/1/')
+    response = api_client.get('/api/trackdb/1')
     assert response.status_code == 200
 
 
 def test_get_trackdb_success(project_dir, api_client, create_trackhub_resource):
-    response = api_client.get('/api/trackdb/1/')
+    response = api_client.get('/api/trackdb/1')
     actual_result = response.json()
     assert response.status_code == 200
     # assert that 'owner', 'created', 'hub'.. fields are in actual_result
@@ -30,7 +30,7 @@ def test_get_trackdb_success(project_dir, api_client, create_trackhub_resource):
 
 def test_get_one_trackdb_fail(api_client, create_trackhub_resource):
     expected_result = {'detail': 'Not found.'}
-    response = api_client.get('/api/trackdb/144/')
+    response = api_client.get('/api/trackdb/144')
     actual_result = response.json()
     assert response.status_code == 404
     assert actual_result == expected_result

--- a/trackdbs/tests.py
+++ b/trackdbs/tests.py
@@ -30,7 +30,7 @@ def test_get_trackdb_success(project_dir, api_client, create_trackhub_resource):
 
 def test_get_one_trackdb_fail(api_client, create_trackhub_resource):
     expected_result = {'detail': 'Not found.'}
-    response = api_client.get('/api/trackhub/144/')
+    response = api_client.get('/api/trackdb/144/')
     actual_result = response.json()
     assert response.status_code == 404
     assert actual_result == expected_result

--- a/trackdbs/urls.py
+++ b/trackdbs/urls.py
@@ -17,5 +17,5 @@ from .views import TrackdbDetail
 
 
 urlpatterns = [
-    path('<int:pk>/', TrackdbDetail.as_view()),
+    path('/<int:pk>', TrackdbDetail.as_view()),
 ]

--- a/trackhubs/tests/tests_api.py
+++ b/trackhubs/tests/tests_api.py
@@ -27,7 +27,7 @@ def test_post_trackhub_success(project_dir, api_client, create_user_resource, cr
         },
         'type': 'genomics'
     }
-    response = api_client.post('/api/trackhub/', submitted_hub, format='json')
+    response = api_client.post('/api/trackhub', submitted_hub, format='json')
     # print("## Response message: {}".format(response.content.decode()))
     assert response.status_code == 201
 
@@ -38,7 +38,7 @@ def test_post_trackhub_bad_url(api_client, create_user_resource):
     submitted_hub = {
         'url': 'https://some.random/bad/url/hub.txt'
     }
-    response = api_client.post('/api/trackhub/', submitted_hub, format='json')
+    response = api_client.post('/api/trackhub', submitted_hub, format='json')
     assert response.status_code == 400
 
 
@@ -49,7 +49,7 @@ def test_post_trackhub_no_url_field(project_dir, api_client, create_user_resourc
         # 'wrong_field_name': 'file:///' + str(project_dir) + '/' + 'samples/JASPAR_TFBS/hub.txt'
         'wrong_field_name': 'https://raw.githubusercontent.com/Ensembl/thr/master/samples/JASPAR_TFBS/hub.txt'
     }
-    response = api_client.post('/api/trackhub/', submitted_hub, format='json')
+    response = api_client.post('/api/trackhub', submitted_hub, format='json')
     assert response.status_code == 400
 
 
@@ -58,12 +58,12 @@ def test_post_trackhub_without_login(project_dir, api_client):
         # 'url': 'file:///' + str(project_dir) + '/' + 'samples/JASPAR_TFBS/hub.txt'
         'url': 'https://raw.githubusercontent.com/Ensembl/thr/master/samples/JASPAR_TFBS/hub.txt'
     }
-    response = api_client.post('/api/trackhub/', submitted_hub, format='json')
+    response = api_client.post('/api/trackhub', submitted_hub, format='json')
     assert response.status_code == 401
 
 
 def test_get_trackhub_without_login(api_client):
-    response = api_client.get('/api/trackhub/')
+    response = api_client.get('/api/trackhub')
     assert response.status_code == 401
 
 
@@ -98,7 +98,7 @@ def test_get_trackhub_success(project_dir, api_client, create_trackhub_resource)
             }]
     }]
 
-    response = api_client.get('/api/trackhub/')
+    response = api_client.get('/api/trackhub')
     actual_result = response.json()
     assert response.status_code == 200
     assert actual_result[0]['hub_id'] == expected_result[0]['hub_id']
@@ -147,7 +147,7 @@ def test_get_one_trackhub_success(project_dir, api_client, create_trackhub_resou
         ]
     }
 
-    response = api_client.get('/api/trackhub/1/')
+    response = api_client.get('/api/trackhub/1')
     actual_result = response.json()
     assert response.status_code == 200
     # assert actual_result['hub_id'] == expected_result['hub_id']
@@ -158,7 +158,7 @@ def test_get_one_trackhub_success(project_dir, api_client, create_trackhub_resou
 
 def test_get_one_trackhub_fail(api_client, create_trackhub_resource):
     expected_result = {'detail': 'Not found.'}
-    response = api_client.get('/api/trackhub/144/')
+    response = api_client.get('/api/trackhub/144')
     actual_result = response.json()
     assert response.status_code == 404
     assert actual_result == expected_result
@@ -172,5 +172,5 @@ def test_get_one_trackhub_fail(api_client, create_trackhub_resource):
     ]
 )
 def test_delete_trackhub(api_client, create_trackhub_resource, hub_id, expected_status_code):
-    response = api_client.delete('/api/trackhub/{}/'.format(hub_id))
+    response = api_client.delete('/api/trackhub/{}'.format(hub_id))
     assert response.status_code == expected_status_code

--- a/trackhubs/urls.py
+++ b/trackhubs/urls.py
@@ -18,5 +18,5 @@ from trackhubs import views
 
 urlpatterns = [
     path('', views.TrackHubList.as_view()),
-    path('<int:pk>/', views.TrackHubDetail.as_view()),
+    path('<int:pk>', views.TrackHubDetail.as_view()),
 ]

--- a/trackhubs/urls.py
+++ b/trackhubs/urls.py
@@ -18,5 +18,5 @@ from trackhubs import views
 
 urlpatterns = [
     path('', views.TrackHubList.as_view()),
-    path('<int:pk>', views.TrackHubDetail.as_view()),
+    path('/<int:pk>', views.TrackHubDetail.as_view()),
 ]

--- a/users/urls.py
+++ b/users/urls.py
@@ -18,7 +18,7 @@ from users.views import RegistrationViewAPI, LogoutViewAPI, UserDetailsView, Cha
     LoginViewAPI, ValidateResetPasswordAPI, ResetPasswordEmailView, SetNewPasswordAPI
 
 urlpatterns = [
-    path('user/', UserDetailsView.as_view(), name='user_api'),
+    path('user', UserDetailsView.as_view(), name='user_api'),
     path('register', RegistrationViewAPI.as_view(), name='register_api'),
     path('login', LoginViewAPI.as_view(), name='login_api'),
     path('logout', LogoutViewAPI.as_view(), name='logout_api'),


### PR DESCRIPTION
JIRA Tickets:
* https://www.ebi.ac.uk/panda/jira/browse/EA-1020
* https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6727

Changes:
* Fixed trailing slashes in URLs, now `https://test.trackhubregistry.org/api/search?page=1` should work fine (it was `https://test.trackhubregistry.org/api/search/?page=1` before).
* Added `entries_per_page` parameter.
* Fixed broken tests.

Once these changes are merged,
```
curl -X POST -d '{"assembly":"GRCh38"}' -H "Content-Type: application/json" https://test.trackhubregistry.org/api/search?page=1&entries_per_page=5
```
Should work as expected.