### PR TITLE
Change search API short_label and long_label fields to camel case

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -119,8 +119,8 @@ def create_hub_resource(create_user_resource, create_datatype_resource):
     user, _ = create_user_resource
     actual_hub_obj = trackhubs.models.Hub.objects.create(
         name='JASPAR_TFBS',
-        short_label='JASPAR TFBS',
-        long_label='TFBS predictions for profiles in the JASPAR CORE collections',
+        shortLabel='JASPAR TFBS',
+        longLabel='TFBS predictions for profiles in the JASPAR CORE collections',
         url='https://url/to/the/hub.txt',
         description_url='http://jaspar.genereg.net/genome-tracks/',
         email='wyeth@cmmt.ubc.ca',
@@ -172,8 +172,8 @@ def create_track_resource(create_trackdb_resource, create_filetype_resource, cre
     actual_track_obj = trackhubs.models.Track.objects.create(
         # save name only without 'on' or 'off' settings
         name='JASPAR2020_TFBS_hg19',
-        short_label='JASPAR2020 TFBS hg19',
-        long_label='TFBS predictions for all profiles in the JASPAR CORE vertebrates collection (2020)',
+        shortLabel='JASPAR2020 TFBS hg19',
+        longLabel='TFBS predictions for all profiles in the JASPAR CORE vertebrates collection (2020)',
         big_data_url='http://path.to/the/track/bigbed/file/JASPAR2020_hg19.bb',
         parent=None,
         trackdb=create_trackdb_resource,
@@ -193,8 +193,8 @@ def create_child_track_resource(create_trackdb_resource, create_filetype_resourc
     actual_track_obj = trackhubs.models.Track.objects.create(
         # save name only without 'on' or 'off' settings
         name='Child track name',
-        short_label='child of JASPAR2020',
-        long_label='This is the child of the track described as follows: TFBS predictions for all profiles in the '
+        shortLabel='child of JASPAR2020',
+        longLabel='This is the child of the track described as follows: TFBS predictions for all profiles in the '
                    'JASPAR CORE vertebrates collection (2020)',
         big_data_url='http://path.to/the/subtrack/bigbed/file/JASPAR2020_hg19_subtrack.bb',
         parent=None,
@@ -215,8 +215,8 @@ def create_child_track_with_parent_resource(create_trackdb_resource, create_file
     actual_track_obj = trackhubs.models.Track.objects.create(
         # save name only without 'on' or 'off' settings
         name='Child track name',
-        short_label='child of JASPAR2020',
-        long_label='This is the child of the track described as follows: TFBS predictions for all profiles in the '
+        shortLabel='child of JASPAR2020',
+        longLabel='This is the child of the track described as follows: TFBS predictions for all profiles in the '
                    'JASPAR CORE vertebrates collection (2020)',
         big_data_url='http://path.to/the/subtrack/bigbed/file/JASPAR2020_hg19_subtrack.bb',
         parent=create_track_resource,

--- a/info/serializers.py
+++ b/info/serializers.py
@@ -43,9 +43,6 @@ class TrackhubInfoSerializer(serializers.ModelSerializer):
     """
 
     trackdbs = serializers.SerializerMethodField()
-    # we rename 'short_label' and 'long_label' to 'shortLabel' and 'longLabel'
-    shortLabel = serializers.CharField(source='short_label')
-    longLabel = serializers.CharField(source='long_label')
 
     class Meta:
         model = models.Hub

--- a/search/documents.py
+++ b/search/documents.py
@@ -59,13 +59,13 @@ class TrackdbDocument(Document):
                 'raw': fields.KeywordField(),
             }
         ),
-        'short_label': fields.TextField(
+        'shortLabel': fields.TextField(
             analyzer=html_strip,
             fields={
                 'raw': fields.KeywordField(),
             }
         ),
-        'long_label': fields.TextField(
+        'longLabel': fields.TextField(
             analyzer=html_strip,
             fields={
                 'raw': fields.KeywordField(),

--- a/search/serializers.py
+++ b/search/serializers.py
@@ -51,11 +51,8 @@ class TrackdbDocumentSerializer(DocumentSerializer):
     def get_status(self, obj):
         """Represent status value."""
         try:
-            minimal_status_info = {
-                "last_update": obj.status.last_update,
-                "message": obj.status.message
-            }
-            return minimal_status_info
+            # Convert elasticsearch_dsl.utils.AttrDict to Dictionary and return it
+            return obj.status.to_dict()
         except Exception:
             return None
 

--- a/search/views.py
+++ b/search/views.py
@@ -173,7 +173,7 @@ class TrackdbDocumentListView(DocumentViewSet):
     ]
     # Define search fields
     search_fields = (
-        'hub.short_label', 'hub.long_label', 'hub.name',
+        'hub.shortLabel', 'hub.longLabel', 'hub.name',
         'type', 'species.common_name', 'species.scientific_name',
         'assembly.name', 'assembly.ucsc_synonym', 'assembly.accession'
     )

--- a/trackdbs/serializers.py
+++ b/trackdbs/serializers.py
@@ -26,8 +26,8 @@ class TrackdbHubSerializer(serializers.ModelSerializer):
         model = models.Hub
         fields = [
             'name',
-            'short_label',
-            'long_label',
+            'shortLabel',
+            'longLabel',
             'url',
         ]
 

--- a/trackdbs/update_trackdb.py
+++ b/trackdbs/update_trackdb.py
@@ -14,6 +14,7 @@
 import logging
 import trackhubs
 from trackhubs.tracks_status import fetch_tracks_status
+from thr.settings.base import ELASTICSEARCH_INDEX_NAMES
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +39,8 @@ def update_one_trackdb(trackdb_id):
     """
     Update the status of one specific trackdb and enrich ES docs
     """
+    # Get es_index_name from settings
+    es_index_name = ELASTICSEARCH_INDEX_NAMES['search.documents']
     # Get the current trackdb object
     one_trackdb = trackhubs.models.Trackdb.objects.filter(trackdb_id=trackdb_id).first()
     # Get all tracks belonging to the current trackdb object
@@ -49,7 +52,11 @@ def update_one_trackdb(trackdb_id):
         one_trackdb.status = tracks_status
         one_trackdb.save()
         # Update ES document
-        one_trackdb.update_trackdb_document(one_trackdb.hub, one_trackdb.data, one_trackdb.configuration, tracks_status)
+        one_trackdb.update_trackdb_document(
+            one_trackdb.hub, one_trackdb.data,
+            one_trackdb.configuration, tracks_status,
+            es_index_name
+        )
         logger.info('Status updated successfully: ', tracks_status)
 
     return one_trackdb

--- a/trackhubs/models.py
+++ b/trackhubs/models.py
@@ -482,10 +482,9 @@ class Trackdb(models.Model):
                                                                                                 short_label_stripped)
         return browser_links
 
-    def update_trackdb_document(self, hub, trackdb_data, trackdb_configuration, tracks_status, index='trackhubs'):
+    def update_trackdb_document(self, hub, trackdb_data, trackdb_configuration, tracks_status, index):
         # pylint: disable=too-many-arguments
         """
-        TODO: find a way to switch between index='trackhubs' and index='test_trackhubs' indices
         Update trackdb document in Elascticsearch with the additional data provided
         :param trackdb: trackdb object to be updated
         :param file_type: file type associated with this track
@@ -504,7 +503,6 @@ class Trackdb(models.Model):
                 max_retries=10,
                 retry_on_timeout=True
             )
-
             es_conn.update(
                 index=index,
                 id=self.trackdb_id,

--- a/trackhubs/models.py
+++ b/trackhubs/models.py
@@ -76,8 +76,8 @@ class Hub(models.Model):
 
     hub_id = models.AutoField(primary_key=True)
     name = models.CharField(max_length=255)
-    short_label = models.TextField(blank=True, null=True)
-    long_label = models.TextField(blank=True, null=True)
+    shortLabel = models.TextField(blank=True, null=True)
+    longLabel = models.TextField(blank=True, null=True)
     url = models.CharField(max_length=255)
     description_url = models.URLField(null=True)
     email = models.EmailField(null=True)
@@ -286,9 +286,9 @@ class Trackdb(models.Model):
         division = None
 
         # Get the hub url and short label using hub id in trackdb object
-        hub_url_and_short_label = Hub.objects.filter(hub_id=self.hub_id).values('url', 'short_label').first()
+        hub_url_and_short_label = Hub.objects.filter(hub_id=self.hub_id).values('url', 'shortLabel').first()
         hub_url = hub_url_and_short_label['url']
-        hub_short_label = hub_url_and_short_label['short_label']
+        hub_short_label = hub_url_and_short_label['shortLabel']
         short_label_stripped = remove_html_tags(hub_short_label).strip()  # .replace(' ', '%20')
 
         # Get the assembly name and ucsc synonym using assembly id in trackdb object
@@ -544,8 +544,8 @@ class Track(models.Model):
 
     track_id = models.AutoField(primary_key=True)
     name = models.CharField(max_length=255)
-    short_label = models.TextField(blank=True, null=True)
-    long_label = models.TextField(blank=True, null=True)
+    shortLabel = models.TextField(blank=True, null=True)
+    longLabel = models.TextField(blank=True, null=True)
     big_data_url = models.TextField(blank=True, null=True)
     html = models.CharField(max_length=255, null=True)
     meta = models.CharField(max_length=255, null=True)

--- a/trackhubs/serializers.py
+++ b/trackhubs/serializers.py
@@ -25,8 +25,8 @@ class HubSerializer(serializers.ModelSerializer):
         fields = [
             'hub_id',
             'name',
-            'short_label',
-            'long_label',
+            'shortLabel',
+            'longLabel',
             'url',
             'description_url',
             'email'
@@ -57,8 +57,8 @@ class CustomOneHubSerializer(serializers.ModelSerializer):
         model = models.Hub
         fields = [
             'name',
-            'short_label',
-            'long_label',
+            'shortLabel',
+            'longLabel',
             'url',
             'trackdbs'
         ]

--- a/trackhubs/tests/test_translator.py
+++ b/trackhubs/tests/test_translator.py
@@ -62,8 +62,8 @@ def test_save_hub(create_hub_resource):
     }
 
     assert expected_hub_info['hub'] == create_hub_resource.name
-    assert expected_hub_info['shortLabel'] == create_hub_resource.short_label
-    assert expected_hub_info['longLabel'] == create_hub_resource.long_label
+    assert expected_hub_info['shortLabel'] == create_hub_resource.shortLabel
+    assert expected_hub_info['longLabel'] == create_hub_resource.longLabel
     assert expected_hub_info['email'] == create_hub_resource.email
     assert expected_hub_info['descriptionUrl'] == create_hub_resource.description_url
     assert expected_hub_info['url'] == create_hub_resource.url
@@ -102,8 +102,8 @@ def test_save_track(create_track_resource):
     }
 
     assert expected_track_info['track'] == create_track_resource.name
-    assert expected_track_info['shortLabel'] == create_track_resource.short_label
-    assert expected_track_info['longLabel'] == create_track_resource.long_label
+    assert expected_track_info['shortLabel'] == create_track_resource.shortLabel
+    assert expected_track_info['longLabel'] == create_track_resource.longLabel
     assert expected_track_info['bigDataUrl'] == create_track_resource.big_data_url
 
 

--- a/trackhubs/tests/tests_api.py
+++ b/trackhubs/tests/tests_api.py
@@ -71,8 +71,8 @@ def test_get_trackhub_success(project_dir, api_client, create_trackhub_resource)
     expected_result = [{
         'hub_id': 1,
         'name': 'JASPAR_TFBS',
-        'short_label': 'JASPAR TFBS',
-        'long_label': 'TFBS predictions for profiles in the JASPAR CORE collections',
+        'shortLabel': 'JASPAR TFBS',
+        'longLabel': 'TFBS predictions for profiles in the JASPAR CORE collections',
         # 'url': 'file:///' + str(project_dir) + '/' + 'samples/JASPAR_TFBS/hub.txt',
         'url': 'https://raw.githubusercontent.com/Ensembl/thr/master/samples/JASPAR_TFBS/hub.txt',
         'description_url': 'http://jaspar.genereg.net/genome-tracks/',
@@ -111,8 +111,8 @@ def test_get_one_trackhub_success(project_dir, api_client, create_trackhub_resou
     expected_result = {
         'hub_id': 1,
         'name': 'JASPAR_TFBS',
-        'short_label': 'JASPAR TFBS',
-        'long_label': 'TFBS predictions for profiles in the JASPAR CORE collections',
+        'shortLabel': 'JASPAR TFBS',
+        'longLabel': 'TFBS predictions for profiles in the JASPAR CORE collections',
         # 'url': 'file:///' + str(project_dir) + '/' + 'samples/JASPAR_TFBS/hub.txt',
         'url': 'https://raw.githubusercontent.com/Ensembl/thr/master/samples/JASPAR_TFBS/trackDb.txt',
         'description_url': 'http://jaspar.genereg.net/genome-tracks/',

--- a/trackhubs/translator.py
+++ b/trackhubs/translator.py
@@ -26,6 +26,7 @@ from trackhubs.hub_check import hub_check
 from trackhubs.models import Trackdb, GenomeAssemblyDump
 from trackhubs.parser import parse_file_from_url
 from trackhubs.tracks_status import fetch_tracks_status, fix_big_data_url
+from thr.settings.base import ELASTICSEARCH_INDEX_NAMES
 
 User = get_user_model()
 
@@ -312,6 +313,9 @@ def save_and_update_document(hub_url, data_type, current_user):
     :param current_user: the submitter (current user) id
     :returns: the hub information if the submission was successful otherwise it returns an error
     """
+    # Get es_index_name from settings
+    es_index_name = ELASTICSEARCH_INDEX_NAMES['search.documents']
+
     base_url = hub_url[:hub_url.rfind('/')]
 
     # TODO: this three lines should be moved somewhere else where they are executed only once
@@ -461,7 +465,11 @@ def save_and_update_document(hub_url, data_type, current_user):
             current_trackdb.data = trackdb_data
             current_trackdb.save()
             # Update Elasticsearch trackdb document
-            trackdb_obj.update_trackdb_document(hub_obj, trackdb_data, trackdb_configuration, tracks_status)
+            trackdb_obj.update_trackdb_document(
+                hub_obj, trackdb_data,
+                trackdb_configuration, tracks_status,
+                es_index_name
+            )
 
         return {'success': 'The hub is submitted successfully'}
 

--- a/trackhubs/translator.py
+++ b/trackhubs/translator.py
@@ -98,8 +98,8 @@ def save_hub(hub_dict, data_type, current_user):
     # TODO: Add try expect if the 'hub' or 'url' is empty
     new_hub_obj = trackhubs.models.Hub(
         name=hub_dict['hub'],
-        short_label=hub_dict.get('shortLabel'),
-        long_label=hub_dict.get('longLabel'),
+        shortLabel=hub_dict.get('shortLabel'),
+        longLabel=hub_dict.get('longLabel'),
         url=hub_dict['url'],
         description_url=hub_dict.get('descriptionUrl'),
         email=hub_dict.get('email'),
@@ -162,8 +162,8 @@ def save_track(track_dict, trackdb, file_type, visibility):
     new_track_obj = trackhubs.models.Track(
         # save name only without 'on' or 'off' settings
         name=get_first_word(track_dict['track']),
-        short_label=track_dict.get('shortLabel'),
-        long_label=track_dict.get('longLabel'),
+        shortLabel=track_dict.get('shortLabel'),
+        longLabel=track_dict.get('longLabel'),
         big_data_url=track_dict.get('bigDataUrl'),
         html=track_dict.get('html'),
         parent=None,  # track id will go here later on using add_parent_id() function


### PR DESCRIPTION
https://www.ebi.ac.uk/panda/jira/browse/EA-1020

### Changes

* Changed search API short_label and long_label fields to camel case
* Made it easier to switch between ES indices
* Return the whole `status` object when using search API