### PR TITLE
Switch to use pymysql instead of mysqlclient

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,6 @@ lazy-object-proxy==1.6.0
 mccabe==0.6.1
 mock==4.0.2
 more-itertools==8.5.0
-mysqlclient==2.2.4
 packaging==20.4
 pluggy==0.13.1
 py==1.11.0
@@ -32,6 +31,7 @@ PyJWT==2.4.0
 pylint==2.9.5
 pylint-django==2.4.4
 pylint-plugin-utils==0.6
+PyMySQL==1.1.2
 pyparsing==2.4.7
 pytest==7.2.2
 pytest-cov==2.10.1

--- a/search/views.py
+++ b/search/views.py
@@ -35,7 +35,7 @@ from elasticsearch_dsl import (
     TermsFacet
 )
 
-from thr.settings import FACETS_LENGHT
+from thr.settings import FACETS_LENGTH
 
 
 # We're overriding some methods since we need to stick with POST /search/
@@ -145,13 +145,13 @@ class CustomPageNumberPagination(PageNumberPagination):
 class CustomTermsFacet(TermsFacet):
     """
     Override get_aggregation in Facet to increase
-    the bucket size from 10 to FACETS_LENGHT
-    specified in base.py config file
+    the bucket size from 10 to FACETS_LENGTH
+    specified in the base.py config file
     """
     def get_aggregation(self):
-        agg = A(self.agg_type, **self._params, size=FACETS_LENGHT)
+        agg = A(self.agg_type, **self._params, size=FACETS_LENGTH)
         if self._metric:
-            agg.metric('metric', self._metric, size=FACETS_LENGHT)
+            agg.metric('metric', self._metric, size=FACETS_LENGTH)
         return agg
 
 

--- a/thr/settings/__init__.py
+++ b/thr/settings/__init__.py
@@ -12,4 +12,9 @@
    limitations under the License.
 """
 
+import pymysql
+# This line makes Django think "I'm using MySQLdb/mysqlclient",
+# but under the hood it uses PyMySQL (pure Python).
+pymysql.install_as_MySQLdb()
+
 from .dev import *

--- a/thr/settings/base.py
+++ b/thr/settings/base.py
@@ -257,8 +257,8 @@ FRONTEND_URL = os.environ.get('FRONTEND_URL', 'localhost:3000')
 BACKEND_URL = os.environ.get('BACKEND_URL', 'localhost:8000')
 
 # The number of elements shown in Species, Assembly
-# and Hub facets can be controlled using FACETS_LENGHT
-FACETS_LENGHT = 30
+# and Hub facets can be controlled using FACETS_LENGTH
+FACETS_LENGTH = 30
 
 # The hub check API is in a separate VM
 HUBCHECK_API_URL = os.environ.get('HUBCHECK_API_URL', 'http://localhost:8888/hubcheck')
@@ -266,4 +266,4 @@ HUBCHECK_API_URL = os.environ.get('HUBCHECK_API_URL', 'http://localhost:8888/hub
 # Whether to append trailing slashes to URLs.
 APPEND_SLASH = False
 
-THR_VERSION = "0.8.2"
+THR_VERSION = "0.9.0"


### PR DESCRIPTION
### Changes
Switch to use `pymysql` instead of `mysqlclient`

In my last attempt to install `mysqlclient` I've got:
```
$ pip install mysqlclient
...
fatal error: 'mysql.h' file not found
-I/opt/homebrew/include/mysql -I/opt/homebrew/include/mariadb
```

This PR switches to use `pymysql` in order to get rid of this issue

---

### Context
When I pointed my local machine to

I'm on MacOS (ARM64, Apple Silicon), and using Homebrew which recently ships MySQL 9.x by default.

The remote database, however, is MySQL 8.x and uses the mysql_native_password plugin for authentication.

This creates two problems:

* The auth plugin mismatch: MySQL 9 client libraries removed the mysql_native_password.so plugin, so even if I build mysqlclient successfully, it can’t log in to a MySQL 8 user that still uses mysql_native_password.

* The build environment problem: The mysqlclient Python package is a C extension. It requires local MySQL/MariaDB headers (`mysql.h`) and libraries (`libmysqlclient.dylib`) to compile.
I don’t have those installed. On macOS ARM, it’s painful to fix because Homebrew doesn’t ship MySQL 8 headers anymore.

**Why PyMySQL fixes both instantly?**

PyMySQL is a pure Python implementation of the MySQL client protocol, that means:

* It does not need to compile C code — so you can pip install it with zero system dependencies.
* It does not use .so plugins like mysql_native_password.so — it implements that auth method in Python, so it connects fine to your MySQL 8 server.
* Django can use it transparently if you add this two-line shim:

```python
import pymysql
pymysql.install_as_MySQLdb()
```

This tricks Django into thinking it’s using MySQLdb (the same API that mysqlclient provides), but underneath it’s actually using PyMySQL.