### PR TITLE
Restore local hubCheck execution for hub validation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,8 +8,8 @@ workflow:
   rules:
     # Allow being triggered from thr_k8s parent pipeline
     - if: '$CI_PIPELINE_SOURCE == "pipeline"'
-    # Keep normal behavior for direct pushes / MRs
-    - if: '$CI_PIPELINE_SOURCE == "push"'
+    # Run for all branch pipelines, including mirrored GitHub updates
+    - if: '$CI_COMMIT_BRANCH'
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
     - when: never
 

--- a/conftest.py
+++ b/conftest.py
@@ -122,33 +122,11 @@ def django_db_use_migrations():
 
 
 @pytest.fixture(autouse=True)
-def hubcheck_requests_mock(monkeypatch):
+def translator_hubcheck_mock(monkeypatch):
     """
-    Mock requests to the hubCheck service.
+    Mock hubCheck calls made through the translator.
     """
-    class _Resp:
-        def __init__(self, status_code, payload):
-            self.status_code = status_code
-            self._payload = payload
-            self.ok = 200 <= status_code < 300
-            self.text = ""
-
-        def json(self):
-            return self._payload
-
-    def _fake_get(url, params=None, **kwargs):
-        hub_url = (params or {}).get("hub_url", "")
-        if "Rfam/12.0/genome_browser_hub/hub.txt" in hub_url:
-            return _Resp(200, {"success": {"mock": True}})
-        if "Track_Hubs/SRP090583/hub.txt" in hub_url:
-            return _Resp(200, {"warning": {"mock": True}})
-        if "databases/not/here/hub.txt" in hub_url:
-            return _Resp(200, {"error": {"mock": True}})
-        return _Resp(200, {"error": {"mock": True}})
-
-    # Patch the module reference in hub_check without mutating the global requests module.
-    # We keep requests.get intact so libraries like responses continue to work.
-    monkeypatch.setattr("trackhubs.hub_check.requests", SimpleNamespace(get=_fake_get))
+    monkeypatch.setattr("trackhubs.translator.hub_check", lambda hub_url: {"success": {"mock": True}})
 
 
 @pytest.fixture(autouse=True)

--- a/thr/settings/base.py
+++ b/thr/settings/base.py
@@ -281,8 +281,5 @@ BACKEND_URL = os.environ.get('BACKEND_URL', 'localhost:8000')
 # and Hub facets can be controlled using FACETS_LENGHT
 FACETS_LENGHT = 30
 
-# The hub check API is in a separate VM
-HUBCHECK_API_URL = os.environ.get('HUBCHECK_API_URL', 'http://localhost:8888/hubcheck')
-
 # Whether to append trailing slashes to URLs.
 APPEND_SLASH = False

--- a/trackhubs/hub_check.py
+++ b/trackhubs/hub_check.py
@@ -12,26 +12,92 @@
    limitations under the License.
 """
 
+import subprocess
 import sys
-import requests
-from thr import settings
+from pathlib import Path
+
+from django.conf import settings
+
+
+HUBCHECK_PATH = settings.BASE_DIR.parent / "tools" / "hubCheck"
+HUBCHECK_DOWNLOAD_URLS = {
+    "linux": "http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/hubCheck",
+    "darwin": "http://hgdownload.soe.ucsc.edu/admin/exe/macOSX.arm64/hubCheck",
+}
+
+
+def _ensure_hubcheck_binary():
+    """
+    Download hubCheck into the local tools directory if it is not already present.
+    """
+    hubcheck = Path(HUBCHECK_PATH)
+    if hubcheck.exists():
+        hubcheck.chmod(0o700)
+        return None
+
+    download_url = HUBCHECK_DOWNLOAD_URLS.get(sys.platform)
+    if not download_url:
+        return {"error": "hubCheck is not available for platform '{}'".format(sys.platform)}
+
+    hubcheck.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        subprocess.run(["curl", "-L", "-o", str(hubcheck), download_url], check=True)
+        hubcheck.chmod(0o700)
+    except (OSError, subprocess.CalledProcessError) as exc:
+        return {"error": "Couldn't download hubCheck: {}".format(exc)}
+
+    return None
 
 
 def hub_check(hub_url):
     """
-    Runs the USCS hubCheck API on the submitted hub
+    Runs the UCSC hubCheck tool on the submitted hub
     :param hub_url: the hub url provided by the submitter
     :returns: the hub information if the submission was successful otherwise it returns an error
     TODO: group 'translator.py', 'hub_check.py', 'constants' and 'parser.py' in 'utils' directory
     """
-    url = settings.HUBCHECK_API_URL
-    payload = {"hub_url": hub_url}
+    download_error = _ensure_hubcheck_binary()
+    if download_error:
+        return download_error
 
     print("[INFO] Checking " + hub_url + "...")
-    response = requests.get(url, params=payload)
-    if not response.ok:
-        print("Couldn't run hubCheck, reason: %s [%d]" % (response.text, response.status_code))
-        sys.exit()
+    try:
+        hub_check_result = subprocess.run(
+            [str(HUBCHECK_PATH), "-noTracks", hub_url],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+        )
+    except OSError as exc:
+        return {"error": "Couldn't run hubCheck: {}".format(exc)}
 
-    hub_check_result = response.json()
-    return hub_check_result
+    lines = hub_check_result.stdout.splitlines()
+    line_0 = lines[0] if lines else ""
+    other_lines = lines[1:]
+
+    # hubCheck exits with code 1 even if there are only warnings.
+    # Treat warning-only output as a warning response, and any non-warning line
+    # after the header as an error.
+    warnings = []
+    errors = []
+    if hub_check_result.returncode:
+        for line in other_lines:
+            if line.startswith("warning:"):
+                warnings.append(line)
+            else:
+                errors.append(line)
+
+        if errors or not warnings:
+            return {
+                'error': 'Error in hub {}: {}'.format(hub_url, line_0.strip(':')),
+                'details': errors or other_lines or [line_0],
+            }
+
+        return {
+            'warning': 'Warnings found (they can be ignored)',
+            'details': warnings,
+        }
+
+    return {
+        'success': 'hubCheck done! Nothing to report!'
+    }

--- a/trackhubs/tests/test_hub_check.py
+++ b/trackhubs/tests/test_hub_check.py
@@ -13,26 +13,83 @@
 """
 import pytest
 
-from thr.settings import BASE_DIR
+import trackhubs.hub_check as hub_check_module
 from trackhubs.hub_check import hub_check
 
 
-@pytest.fixture
-def project_dir():
-    return BASE_DIR.parent
+@pytest.fixture(autouse=True)
+def local_hubcheck_binary(tmp_path, monkeypatch):
+    hubcheck = tmp_path / "tools" / "hubCheck"
+    hubcheck.parent.mkdir()
+    hubcheck.touch()
+    monkeypatch.setattr(hub_check_module, "HUBCHECK_PATH", hubcheck)
 
 
 @pytest.mark.parametrize(
-    'test_hub_url, expected_key_in_result',
+    'returncode, stdout, expected_key_in_result',
     [
-        ('ftp://ftp.ebi.ac.uk/pub/databases/Rfam/12.0/genome_browser_hub/hub.txt', 'success'),
-        ('ftp://ftp.ensemblgenomes.org/pub/misc_data/Track_Hubs/SRP090583/hub.txt', 'warning'),
-        ('ftp://ftp.ebi.ac.uk/pub/databases/not/here/hub.txt', 'error'),
+        (0, "No problems detected\n", 'success'),
+        (1, "hub.txt:\nwarning: missing optional description\n", 'warning'),
+        (1, "hub.txt:\nerror: cannot open genomes.txt\n", 'error'),
     ]
 )
-def test_hub_check_all_cases(test_hub_url, expected_key_in_result):
+def test_hub_check_all_cases(monkeypatch, returncode, stdout, expected_key_in_result):
     """
     Test hubCheck utility in the three different scenarios
     """
-    actual_result = hub_check(test_hub_url)
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return type("CompletedProcess", (), {"returncode": returncode, "stdout": stdout})
+
+    monkeypatch.setattr(hub_check_module.subprocess, "run", fake_run)
+
+    actual_result = hub_check("https://example.org/hub.txt")
+
     assert expected_key_in_result in actual_result
+    assert calls[0][0] == [str(hub_check_module.HUBCHECK_PATH), "-noTracks", "https://example.org/hub.txt"]
+
+
+def test_hub_check_downloads_binary_when_missing(tmp_path, monkeypatch):
+    """
+    Test hubCheck is downloaded locally if it is missing.
+    """
+    hubcheck = tmp_path / "tools" / "hubCheck"
+    hubcheck.unlink()
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        if command[0] == "curl":
+            hubcheck.touch()
+            return type("CompletedProcess", (), {"returncode": 0, "stdout": ""})
+        return type("CompletedProcess", (), {"returncode": 0, "stdout": "No problems detected\n"})
+
+    monkeypatch.setattr(hub_check_module, "HUBCHECK_PATH", hubcheck)
+    monkeypatch.setattr(hub_check_module.subprocess, "run", fake_run)
+
+    actual_result = hub_check("https://example.org/hub.txt")
+
+    assert "success" in actual_result
+    assert calls[0][0][0] == "curl"
+    assert calls[1][0] == [str(hubcheck), "-noTracks", "https://example.org/hub.txt"]
+
+
+def test_hub_check_makes_existing_binary_executable(monkeypatch):
+    """
+    Test hubCheck permissions are fixed when the binary already exists.
+    """
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return type("CompletedProcess", (), {"returncode": 0, "stdout": "No problems detected\n"})
+
+    hub_check_module.HUBCHECK_PATH.chmod(0o600)
+    monkeypatch.setattr(hub_check_module.subprocess, "run", fake_run)
+
+    actual_result = hub_check("https://example.org/hub.txt")
+
+    assert "success" in actual_result
+    assert hub_check_module.HUBCHECK_PATH.stat().st_mode & 0o700 == 0o700

--- a/trackhubs/translator.py
+++ b/trackhubs/translator.py
@@ -342,7 +342,7 @@ def save_and_update_document(hub_url, data_type, current_user, run_hubcheck=True
     save_datatype_filetype_visibility(FILE_TYPES, trackhubs.models.FileType)
     save_datatype_filetype_visibility(VISIBILITY, trackhubs.models.Visibility)
 
-    # run the USCS hubCheck tool found in kent tools on the submitted hub
+    # run the UCSC hubCheck tool found in kent tools on the submitted hub
     if run_hubcheck:
         hub_check_result = hub_check(hub_url)
         if 'error' in hub_check_result.keys():


### PR DESCRIPTION
This PR restores local hubCheck execution for hub validation instead of using the VM